### PR TITLE
[wip] feat: add support for storage policies

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -364,7 +364,7 @@ disks are stored.
   `disk_controller_index`.
 
 - `storage_policy` (string) - The name of the storage policy to apply to the disk. The storage policy
-  must already exist on the vCenter Server. If not specified, the default
+  must already exist on the vCenter instance. If not specified, the default
   storage policy of the target datastore is used.
 
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->

--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -363,6 +363,10 @@ disks are stored.
   Only supported by the `vsphere-clone` builder. Mutually exclusive with
   `disk_controller_index`.
 
+- `storage_policy` (string) - The name of the storage policy to apply to the disk. The storage policy
+  must already exist on the vCenter Server. If not specified, the default
+  storage policy of the target datastore is used.
+
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->
 
 

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -865,6 +865,10 @@ JSON Example:
   Only supported by the `vsphere-clone` builder. Mutually exclusive with
   `disk_controller_index`.
 
+- `storage_policy` (string) - The name of the storage policy to apply to the disk. The storage policy
+  must already exist on the vCenter Server. If not specified, the default
+  storage policy of the target datastore is used.
+
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->
 
 

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -866,7 +866,7 @@ JSON Example:
   `disk_controller_index`.
 
 - `storage_policy` (string) - The name of the storage policy to apply to the disk. The storage policy
-  must already exist on the vCenter Server. If not specified, the default
+  must already exist on the vCenter instance. If not specified, the default
   storage policy of the target datastore is used.
 
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->

--- a/builder/vsphere/common/storage_config.go
+++ b/builder/vsphere/common/storage_config.go
@@ -30,6 +30,10 @@ type DiskConfig struct {
 	// Only supported by the `vsphere-clone` builder. Mutually exclusive with
 	// `disk_controller_index`.
 	DiskControllerUnit string `mapstructure:"disk_controller_unit"`
+	// The name of the storage policy to apply to the disk. The storage policy
+	// must already exist on the vCenter Server. If not specified, the default
+	// storage policy of the target datastore is used.
+	StoragePolicyName string `mapstructure:"storage_policy"`
 }
 
 // Disk layout depends on the builder and clone source. For `vsphere-clone`,

--- a/builder/vsphere/common/storage_config.go
+++ b/builder/vsphere/common/storage_config.go
@@ -31,7 +31,7 @@ type DiskConfig struct {
 	// `disk_controller_index`.
 	DiskControllerUnit string `mapstructure:"disk_controller_unit"`
 	// The name of the storage policy to apply to the disk. The storage policy
-	// must already exist on the vCenter Server. If not specified, the default
+	// must already exist on the vCenter instance. If not specified, the default
 	// storage policy of the target datastore is used.
 	StoragePolicyName string `mapstructure:"storage_policy"`
 }

--- a/builder/vsphere/common/storage_config.hcl2spec.go
+++ b/builder/vsphere/common/storage_config.hcl2spec.go
@@ -15,6 +15,7 @@ type FlatDiskConfig struct {
 	DiskEagerlyScrub    *bool   `mapstructure:"disk_eagerly_scrub" cty:"disk_eagerly_scrub" hcl:"disk_eagerly_scrub"`
 	DiskControllerIndex *int    `mapstructure:"disk_controller_index" cty:"disk_controller_index" hcl:"disk_controller_index"`
 	DiskControllerUnit  *string `mapstructure:"disk_controller_unit" cty:"disk_controller_unit" hcl:"disk_controller_unit"`
+	StoragePolicyName   *string `mapstructure:"storage_policy" cty:"storage_policy" hcl:"storage_policy"`
 }
 
 // FlatMapstructure returns a new FlatDiskConfig.
@@ -34,6 +35,7 @@ func (*FlatDiskConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disk_eagerly_scrub":    &hcldec.AttrSpec{Name: "disk_eagerly_scrub", Type: cty.Bool, Required: false},
 		"disk_controller_index": &hcldec.AttrSpec{Name: "disk_controller_index", Type: cty.Number, Required: false},
 		"disk_controller_unit":  &hcldec.AttrSpec{Name: "disk_controller_unit", Type: cty.String, Required: false},
+		"storage_policy":        &hcldec.AttrSpec{Name: "storage_policy", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/driver/disk.go
+++ b/builder/vsphere/driver/disk.go
@@ -18,6 +18,9 @@ type Disk struct {
 	DiskThinProvisioned bool
 	ControllerIndex     int
 	ControllerUnit      string
+	// StoragePolicyID is the UUID of the vSphere storage policy to associate
+	// with this disk. Empty means no explicit policy; the datastore default applies.
+	StoragePolicyID string
 }
 
 type StorageConfig struct {
@@ -29,6 +32,8 @@ type StorageConfig struct {
 // AddStorageDevices adds virtual storage devices to an existing device list.
 // Disks with ControllerUnit attach at explicit addresses; disks without use
 // disk_controller_index against newly created controllers from DiskControllerType.
+// When a disk has a StoragePolicyID, a VirtualMachineDefinedProfileSpec is attached
+// to that disk's device config spec.
 func (c *StorageConfig) AddStorageDevices(existingDevices object.VirtualDeviceList) ([]types.BaseVirtualDeviceConfigSpec, error) {
 	return c.addStorageDevices(existingDevices, storageAttachOptions{linkControllerDevices: true, validateAggregate: true})
 }
@@ -52,6 +57,7 @@ func (c *StorageConfig) addStorageDevices(existingDevices object.VirtualDeviceLi
 
 	newDevices := object.VirtualDeviceList{}
 	typeIndex := 0
+	policyByKey := map[int32]string{}
 
 	var legacyDisks []int
 	var explicitDisks []int
@@ -97,6 +103,9 @@ func (c *StorageConfig) addStorageDevices(existingDevices object.VirtualDeviceLi
 			existingDevices.AssignController(disk, controller)
 			existingDevices = append(existingDevices, disk)
 			newDevices = append(newDevices, disk)
+			if c.Storage[i].StoragePolicyID != "" {
+				policyByKey[disk.Key] = c.Storage[i].StoragePolicyID
+			}
 		}
 
 		typeIndex = len(c.DiskControllerType)
@@ -158,6 +167,9 @@ func (c *StorageConfig) addStorageDevices(existingDevices object.VirtualDeviceLi
 		assignDiskAtUnit(existingDevices, disk, controller, int32(addr.Unit), opts.linkControllerDevices)
 		existingDevices = append(existingDevices, disk)
 		newDevices = append(newDevices, disk)
+		if c.Storage[i].StoragePolicyID != "" {
+			policyByKey[disk.Key] = c.Storage[i].StoragePolicyID
+		}
 		pendingUnits[raw] = struct{}{}
 	}
 
@@ -167,7 +179,26 @@ func (c *StorageConfig) addStorageDevices(existingDevices object.VirtualDeviceLi
 		}
 	}
 
-	return newDevices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
+	specs, err := newDevices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, spec := range specs {
+		vdcs, ok := spec.(*types.VirtualDeviceConfigSpec)
+		if !ok || vdcs.Device == nil {
+			continue
+		}
+		if policyID, ok := policyByKey[vdcs.Device.GetVirtualDevice().Key]; ok {
+			vdcs.Profile = []types.BaseVirtualMachineProfileSpec{
+				&types.VirtualMachineDefinedProfileSpec{
+					ProfileId: policyID,
+				},
+			}
+		}
+	}
+
+	return specs, nil
 }
 
 func (c *StorageConfig) buildDisk(devices object.VirtualDeviceList, dc Disk, index int) *types.VirtualDisk {

--- a/builder/vsphere/driver/disk_test.go
+++ b/builder/vsphere/driver/disk_test.go
@@ -262,3 +262,47 @@ func TestAddStorageDevicesTypePoolExhausted(t *testing.T) {
 		t.Fatalf("expected type pool exhausted error, got %v", err)
 	}
 }
+
+// TestAddStorageDevices_WithStoragePolicy verifies that a disk with a
+// StoragePolicyID gets a VirtualMachineDefinedProfileSpec in its config spec,
+// while a disk without a policy gets no profile entry.
+func TestAddStorageDevices_WithStoragePolicy(t *testing.T) {
+	const policyUUID = "aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+
+	config := &StorageConfig{
+		DiskControllerType: []string{"pvscsi"},
+		Storage: []Disk{
+			{DiskSize: 10240, DiskThinProvisioned: true, ControllerIndex: 0, StoragePolicyID: policyUUID},
+			{DiskSize: 20480, DiskThinProvisioned: true, ControllerIndex: 0},
+		},
+	}
+
+	specs, err := config.AddStorageDevices(object.VirtualDeviceList{})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	// 1 controller + 2 disks
+	if len(specs) != 3 {
+		t.Fatalf("expected 3 specs, got %d", len(specs))
+	}
+
+	// specs[0] = controller (no profile expected)
+	// specs[1] = first disk (policy set)
+	// specs[2] = second disk (no policy)
+	disk0spec := specs[1].(*types.VirtualDeviceConfigSpec)
+	if len(disk0spec.Profile) != 1 {
+		t.Fatalf("expected 1 profile on disk 0, got %d", len(disk0spec.Profile))
+	}
+	profileSpec, ok := disk0spec.Profile[0].(*types.VirtualMachineDefinedProfileSpec)
+	if !ok {
+		t.Fatal("expected VirtualMachineDefinedProfileSpec on disk 0")
+	}
+	if profileSpec.ProfileId != policyUUID {
+		t.Fatalf("expected profile ID %q, got %q", policyUUID, profileSpec.ProfileId)
+	}
+
+	disk1spec := specs[2].(*types.VirtualDeviceConfigSpec)
+	if len(disk1spec.Profile) != 0 {
+		t.Fatalf("expected no profile on disk 1, got %d", len(disk1spec.Profile))
+	}
+}

--- a/builder/vsphere/driver/driver.go
+++ b/builder/vsphere/driver/driver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/pbm"
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/vapi/library"
 	"github.com/vmware/govmomi/vapi/rest"
@@ -55,6 +56,10 @@ type Driver interface {
 	GetOvfOptions(ctx context.Context, config *OvfDeployConfig) ([]types.OvfOptionInfo, error)
 	ResolveContentLibraryItem(libraryName, itemName string) (*library.Item, error)
 	DeployContentLibraryItem(ctx context.Context, config *ContentLibraryDeployConfig, ui packersdk.Ui) (VirtualMachine, error)
+
+	// FindStoragePolicyID resolves a storage policy name to its profile UUID.
+	// Returns an error if the policy does not exist on vCenter.
+	FindStoragePolicyID(name string) (string, error)
 	Cleanup() (error, error)
 }
 
@@ -72,6 +77,7 @@ type VCenterDriver struct {
 	RestClient *RestClient
 	Finder     *find.Finder
 	Datacenter *object.Datacenter
+	pbmClient  *pbm.Client
 }
 
 func NewVCenterDriver(ctx context.Context, client *govmomi.Client, vimClient *vim25.Client, user *url.Userinfo, finder *find.Finder, datacenter *object.Datacenter) *VCenterDriver {
@@ -154,6 +160,25 @@ func NewDriver(config *ConnectConfig) (Driver, error) {
 func (d *VCenterDriver) GetRestClient() *rest.Client {
 	return d.RestClient.client
 }
+
+// FindStoragePolicyID resolves a storage policy name to its profile UUID using
+// the vSphere Policy-Based Management (PBM) API. The PBM client is initialized
+// lazily on first use; it shares the existing VIM25 session.
+func (d *VCenterDriver) FindStoragePolicyID(name string) (string, error) {
+	if d.pbmClient == nil {
+		c, err := pbm.NewClient(d.Ctx, d.VimClient)
+		if err != nil {
+			return "", fmt.Errorf("error initializing PBM client: %v", err)
+		}
+		d.pbmClient = c
+	}
+	id, err := d.pbmClient.ProfileIDByName(d.Ctx, name)
+	if err != nil {
+		return "", fmt.Errorf("storage policy %q not found: %v", name, err)
+	}
+	return id, nil
+}
+
 func (d *VCenterDriver) Cleanup() (error, error) {
 	return d.RestClient.client.Logout(d.Ctx), d.Client.SessionManager.Logout(d.Ctx)
 }

--- a/builder/vsphere/driver/driver_mock.go
+++ b/builder/vsphere/driver/driver_mock.go
@@ -65,6 +65,11 @@ type DriverMock struct {
 	DeployContentLibraryItemShouldFail bool
 	DeployContentLibraryItemError      error
 	DeployContentLibraryItemVM         VirtualMachine
+
+	FindStoragePolicyIDCalled bool
+	FindStoragePolicyIDName   string
+	FindStoragePolicyIDResult string
+	FindStoragePolicyIDErr    error
 }
 
 // NewDriverMock creates a new instance of DriverMock for testing.
@@ -263,6 +268,12 @@ func (d *DriverMock) DeployContentLibraryItem(ctx context.Context, config *Conte
 		d.DeployContentLibraryItemVM = new(VirtualMachineMock)
 	}
 	return d.DeployContentLibraryItemVM, nil
+}
+
+func (d *DriverMock) FindStoragePolicyID(name string) (string, error) {
+	d.FindStoragePolicyIDCalled = true
+	d.FindStoragePolicyIDName = name
+	return d.FindStoragePolicyIDResult, d.FindStoragePolicyIDErr
 }
 
 func (d *DriverMock) Cleanup() (error, error) {

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -269,6 +269,21 @@ func (d *VCenterDriver) CreateVM(config *CreateConfig) (VirtualMachine, error) {
 	}
 	createSpec.DeviceChange = append(createSpec.DeviceChange, storageConfigSpec...)
 
+	// vSphere requires VmProfile on the top-level config spec (which governs
+	// the VM home files: .vmx, .nvram, etc.) whenever any disk carries a
+	// per-disk storage policy profile. Use the first disk's policy for the
+	// VM home so the entire VM lives on compatible storage.
+	for _, disk := range config.StorageConfig.Storage {
+		if disk.StoragePolicyID != "" {
+			createSpec.VmProfile = []types.BaseVirtualMachineProfileSpec{
+				&types.VirtualMachineDefinedProfileSpec{
+					ProfileId: disk.StoragePolicyID,
+				},
+			}
+			break
+		}
+	}
+
 	devices, err = addNetwork(d, devices, config)
 	if err != nil {
 		return nil, err

--- a/builder/vsphere/driver/vm_test.go
+++ b/builder/vsphere/driver/vm_test.go
@@ -151,6 +151,52 @@ func TestVirtualMachineDriver_CreateVMWithMultipleDisks(t *testing.T) {
 	}
 }
 
+// TestVirtualMachineDriver_CreateVM_WithStoragePolicy verifies that CreateVM
+// succeeds when a disk carries a StoragePolicyID, exercising the VmProfile
+// code path in the VM config spec.
+func TestVirtualMachineDriver_CreateVM_WithStoragePolicy(t *testing.T) {
+	sim := mustVPXSimulator(t)
+
+	_, datastore := mustPreCreatedDatastore(t, sim)
+
+	config := &CreateConfig{
+		Name:      "mock-vm-with-policy",
+		Host:      "DC0_H0",
+		Datastore: datastore.Name,
+		NICs: []NIC{
+			{
+				Network:     "VM Network",
+				NetworkCard: "vmxnet3",
+			},
+		},
+		StorageConfig: StorageConfig{
+			DiskControllerType: []string{"pvscsi"},
+			Storage: []Disk{
+				{
+					DiskSize:            10240,
+					DiskThinProvisioned: true,
+					ControllerIndex:     0,
+					StoragePolicyID:     "aaaabbbb-cccc-dddd-eeee-ffffffffffff",
+				},
+				{
+					DiskSize:        20480,
+					ControllerIndex: 0,
+					// No policy on this disk — VmProfile should still be set
+					// from the first disk's policy.
+				},
+			},
+		},
+	}
+
+	vm, err := newSimulatorDriver(sim).CreateVM(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if vm == nil {
+		t.Fatal("expected a VM, got nil")
+	}
+}
+
 func TestVirtualMachineDriver_CloneWithPrimaryDiskResize(t *testing.T) {
 	sim := mustVPXSimulator(t)
 

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -208,12 +208,21 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 
 	var disks []driver.Disk
 	for _, disk := range s.Config.StorageConfig.Storage {
-		disks = append(disks, driver.Disk{
+		dd := driver.Disk{
 			DiskSize:            disk.DiskSize,
 			DiskEagerlyScrub:    disk.DiskEagerlyScrub,
 			DiskThinProvisioned: disk.DiskThinProvisioned,
 			ControllerIndex:     disk.DiskControllerIndex,
-		})
+		}
+		if disk.StoragePolicyName != "" {
+			id, err := d.FindStoragePolicyID(disk.StoragePolicyName)
+			if err != nil {
+				state.Put("error", fmt.Errorf("error resolving storage policy %q: %v", disk.StoragePolicyName, err))
+				return multistep.ActionHalt
+			}
+			dd.StoragePolicyID = id
+		}
+		disks = append(disks, dd)
 	}
 
 	datastoreName := s.Location.Datastore

--- a/builder/vsphere/iso/step_create_test.go
+++ b/builder/vsphere/iso/step_create_test.go
@@ -7,6 +7,7 @@ package iso
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"path"
 	"strings"
@@ -244,7 +245,7 @@ func TestStepCreateVM_Run(t *testing.T) {
 		t.Fatalf("unexpected result: expected '%s' to be called", "CreateVM")
 	}
 	if diff := cmp.Diff(driverMock.CreateConfig, driverCreateConfig(step.Config, step.Location)); diff != "" {
-		t.Fatalf("unexpected result: %s", diff)
+		t.Fatalf("unexpected CreateConfig: %s", diff)
 	}
 	vm, ok := state.GetOk("vm")
 	if !ok {
@@ -405,7 +406,8 @@ func createConfig() *CreateConfig {
 
 // driverCreateConfig converts CreateConfig and LocationConfig into driver.CreateConfig for virtual machine creation.
 // It maps network interfaces, disks, and other configuration details to the required driver.CreateConfig structure.
-func driverCreateConfig(config *CreateConfig, location *common.LocationConfig) *driver.CreateConfig {
+// resolvedPolicyIDs maps disk index to pre-resolved storage policy UUID (empty string = no policy).
+func driverCreateConfig(config *CreateConfig, location *common.LocationConfig, resolvedPolicyIDs ...string) *driver.CreateConfig {
 	var networkCards []driver.NIC
 	for _, nic := range config.NICs {
 		networkCards = append(networkCards, driver.NIC{
@@ -417,13 +419,17 @@ func driverCreateConfig(config *CreateConfig, location *common.LocationConfig) *
 	}
 
 	var disks []driver.Disk
-	for _, disk := range config.StorageConfig.Storage {
-		disks = append(disks, driver.Disk{
+	for i, disk := range config.StorageConfig.Storage {
+		d := driver.Disk{
 			DiskSize:            disk.DiskSize,
 			DiskEagerlyScrub:    disk.DiskEagerlyScrub,
 			DiskThinProvisioned: disk.DiskThinProvisioned,
 			ControllerIndex:     disk.DiskControllerIndex,
-		})
+		}
+		if i < len(resolvedPolicyIDs) {
+			d.StoragePolicyID = resolvedPolicyIDs[i]
+		}
+		disks = append(disks, d)
 	}
 
 	return &driver.CreateConfig{
@@ -442,5 +448,57 @@ func driverCreateConfig(config *CreateConfig, location *common.LocationConfig) *
 		NICs:          networkCards,
 		USBController: config.USBController,
 		Version:       config.Version,
+	}
+}
+
+// TestStepCreateVM_Run_WithStoragePolicy verifies that a storage policy name is
+// resolved to a UUID and forwarded to CreateVM as StoragePolicyID on the disk.
+func TestStepCreateVM_Run_WithStoragePolicy(t *testing.T) {
+	const policyName = "gold-policy"
+	const policyUUID = "aaaabbbb-cccc-dddd-eeee-ffffffffffff"
+
+	state := basicStateBag()
+	driverMock := driver.NewDriverMock()
+	driverMock.FindStoragePolicyIDResult = policyUUID
+	state.Put("driver", driverMock)
+
+	config := createConfig()
+	config.StorageConfig.Storage[0].StoragePolicyName = policyName
+
+	step := &StepCreateVM{Config: config, Location: basicLocationConfig()}
+
+	if action := step.Run(context.TODO(), state); action == multistep.ActionHalt {
+		t.Fatalf("unexpected halt: %v", state.Get("error"))
+	}
+
+	if !driverMock.FindStoragePolicyIDCalled {
+		t.Fatal("expected FindStoragePolicyID to be called")
+	}
+	if driverMock.FindStoragePolicyIDName != policyName {
+		t.Fatalf("expected policy name %q, got %q", policyName, driverMock.FindStoragePolicyIDName)
+	}
+	if diff := cmp.Diff(driverMock.CreateConfig, driverCreateConfig(config, basicLocationConfig(), policyUUID)); diff != "" {
+		t.Fatalf("unexpected CreateConfig: %s", diff)
+	}
+}
+
+// TestStepCreateVM_Run_StoragePolicyNotFound verifies that a missing storage
+// policy causes the step to halt with a descriptive error.
+func TestStepCreateVM_Run_StoragePolicyNotFound(t *testing.T) {
+	state := basicStateBag()
+	driverMock := driver.NewDriverMock()
+	driverMock.FindStoragePolicyIDErr = fmt.Errorf("no pbm profile found with name: %q", "nonexistent")
+	state.Put("driver", driverMock)
+
+	config := createConfig()
+	config.StorageConfig.Storage[0].StoragePolicyName = "nonexistent"
+
+	step := &StepCreateVM{Config: config, Location: basicLocationConfig()}
+
+	if action := step.Run(context.TODO(), state); action != multistep.ActionHalt {
+		t.Fatalf("expected ActionHalt, got %v", action)
+	}
+	if state.Get("error") == nil {
+		t.Fatal("expected an error in state, got nil")
 	}
 }

--- a/docs-partials/builder/vsphere/common/DiskConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/DiskConfig-not-required.mdx
@@ -16,4 +16,8 @@
   Only supported by the `vsphere-clone` builder. Mutually exclusive with
   `disk_controller_index`.
 
+- `storage_policy` (string) - The name of the storage policy to apply to the disk. The storage policy
+  must already exist on the vCenter Server. If not specified, the default
+  storage policy of the target datastore is used.
+
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->

--- a/docs-partials/builder/vsphere/common/DiskConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/DiskConfig-not-required.mdx
@@ -17,7 +17,7 @@
   `disk_controller_index`.
 
 - `storage_policy` (string) - The name of the storage policy to apply to the disk. The storage policy
-  must already exist on the vCenter Server. If not specified, the default
+  must already exist on the vCenter instance. If not specified, the default
   storage policy of the target datastore is used.
 
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

### Summary

Adds per-disk storage policy support to the `vsphere-iso` builder (and the shared `DiskConfig` used by `vsphere-clone`).

A new optional `storage_policy` field on each `storage {}` block accepts a vSphere storage policy name. At build time the plugin resolves the name to a profile UUID via the Policy-Based Management (PBM) API and attaches a `VirtualMachineDefinedProfileSpec` to the disk's device config spec. The VM home files (`.vmx`, `.nvram`, etc.) are also placed under the same policy via `VirtualMachineConfigSpec.VmProfile`, which the vSphere API requires whenever any disk carries a per-disk profile. If the field is left empty the behaviour is unchanged — the datastore's default policy applies.

The PBM client is initialised lazily on first use from the existing VIM25 session, so no new connection or credential is needed.

Example usage:

```hcl
disk_controller_type = ["pvscsi"]

storage {
  disk_size             = 20480
  disk_thin_provisioned = true
  storage_policy        = "Gold Storage Policy"
}
```

### Type

- [ ] `fix`: Bug Fix
- [x] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

The new field is optional. Existing templates without `storage_policy` are unaffected.

### Tests

- [x] Tests have been added or updated.
- [x] Tests have been completed.

New unit tests:

| File | Test | What it covers |
|---|---|---|
| `driver/disk_test.go` | `TestAddStorageDevices_WithStoragePolicy` | `VirtualMachineDefinedProfileSpec` is attached to the correct disk's `VirtualDeviceConfigSpec`; absent on disks without a policy |
| `driver/vm_test.go` | `TestVirtualMachineDriver_CreateVM_WithStoragePolicy` | `CreateVM` succeeds end-to-end via the govmomi simulator when a disk carries a `StoragePolicyID`, exercising the `VmProfile` branch of the VM config spec |
| `iso/step_create_test.go` | `TestStepCreateVM_Run_WithStoragePolicy` | Policy name is resolved to a UUID and forwarded as `StoragePolicyID` on the driver disk |
| `iso/step_create_test.go` | `TestStepCreateVM_Run_StoragePolicyNotFound` | Step halts with a clear error when the policy name does not exist on vCenter |

Output:

```
ok  github.com/vmware/packer-plugin-vsphere/builder/vsphere/driver  4.158s
ok  github.com/vmware/packer-plugin-vsphere/builder/vsphere/iso     1.771s
ok  github.com/vmware/packer-plugin-vsphere/builder/vsphere/common  1.815s
ok  github.com/vmware/packer-plugin-vsphere/builder/vsphere/clone   0.612s
```

The feature was also validated against a live vCenter with a real storage policy.

### Documentation

- [x] Documentation has been added or updated.

`docs-partials/builder/vsphere/common/DiskConfig-not-required.mdx` was updated with the new `storage_policy` field. This partial is shared between `vsphere-iso` and `vsphere-clone` docs.

### Issue References

Closes #18

### Release Note

```
- Added `storage_policy` field to `storage {}` blocks in the `vsphere-iso` and `vsphere-clone` builders, enabling per-disk vSphere storage policy assignment. (#18)
```

### Additional Information

**Implementation notes:**

- The PBM client (`govmomi/pbm`) is already an indirect dependency via `govmomi` — no new module dependency is introduced.
- Policy name resolution happens at build time (the `Run` step), not during `Prepare`, so the error message includes the vCenter-side policy name and is actionable.
- `VirtualMachineConfigSpec.VmProfile` is set to the first disk's policy when any disk carries a policy. This is required by the vSphere API and mirrors the behaviour of other tools (Terraform provider, govc). If disks have mixed policies the VM home uses the first disk's policy; a dedicated VM-home policy field can be added in a follow-up.
