### PR TITLE
feat: add `disable_ip_wait `option to skip ip wait

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -1589,11 +1589,22 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
   documentation for full details.
 
 - `ip_wait_address` (\*string) - Set this to a CIDR address to cause the service to wait for an address that is contained in
-  this network range. Defaults to `0.0.0.0/0` for any IPv4 address. Examples include:
+  this network range. Defaults to `0.0.0.0/0` for any IPv4 address.
   
+  -> **Note:** This only filters which guest-reported IP is accepted; it does not disable IP wait. Use `disable_ip_wait` to skip
+  waiting for a guest-reported IP entirely. When `disable_ip_wait` is true, this setting still applies to HTTP IP discovery.
+  
+  Examples include:
   * empty string ("") - remove all filters
   * `0:0:0:0:0:0:0:0/0` - allow only ipv6 addresses
   * `192.168.1.0/24` - only allow ipv4 addresses from 192.168.1.1 to 192.168.1.254
+
+- `disable_ip_wait` (bool) - When true, skip waiting for a guest-reported IP from vCenter. The default wait relies on
+  VMware Tools or open-vm-tools guest information. Use when they cannot be installed during
+  guest operating system install. Defaults to `false`.
+  
+  -> **Note:** You must set `ssh_host` or `winrm_host`; reachability timing uses `ssh_timeout`
+  or `winrm_timeout`, not `ip_wait_timeout`.
 
 <!-- End of code generated from the comments of the WaitIpConfig struct in builder/vsphere/common/step_wait_for_ip.go; -->
 

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -1204,11 +1204,22 @@ JSON Example:
   documentation for full details.
 
 - `ip_wait_address` (\*string) - Set this to a CIDR address to cause the service to wait for an address that is contained in
-  this network range. Defaults to `0.0.0.0/0` for any IPv4 address. Examples include:
+  this network range. Defaults to `0.0.0.0/0` for any IPv4 address.
   
+  -> **Note:** This only filters which guest-reported IP is accepted; it does not disable IP wait. Use `disable_ip_wait` to skip
+  waiting for a guest-reported IP entirely. When `disable_ip_wait` is true, this setting still applies to HTTP IP discovery.
+  
+  Examples include:
   * empty string ("") - remove all filters
   * `0:0:0:0:0:0:0:0/0` - allow only ipv6 addresses
   * `192.168.1.0/24` - only allow ipv4 addresses from 192.168.1.1 to 192.168.1.254
+
+- `disable_ip_wait` (bool) - When true, skip waiting for a guest-reported IP from vCenter. The default wait relies on
+  VMware Tools or open-vm-tools guest information. Use when they cannot be installed during
+  guest operating system install. Defaults to `false`.
+  
+  -> **Note:** You must set `ssh_host` or `winrm_host`; reachability timing uses `ssh_timeout`
+  or `winrm_timeout`, not `ip_wait_timeout`.
 
 <!-- End of code generated from the comments of the WaitIpConfig struct in builder/vsphere/common/step_wait_for_ip.go; -->
 

--- a/builder/vsphere/clone/builder.go
+++ b/builder/vsphere/clone/builder.go
@@ -150,9 +150,15 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 				Ctx:    b.config.ctx,
 				VMName: b.config.VMName,
 			},
-			&common.StepWaitForIp{
+		)
+
+		if !b.config.DisableIpWait {
+			steps = append(steps, &common.StepWaitForIp{
 				Config: &b.config.WaitIpConfig,
-			},
+			})
+		}
+
+		steps = append(steps,
 			&communicator.StepConnect{
 				Config:    &b.config.Comm,
 				Host:      common.CommHost(b.config.Comm.Host()),

--- a/builder/vsphere/clone/config.go
+++ b/builder/vsphere/clone/config.go
@@ -99,6 +99,10 @@ func (c *Config) Prepare(raws ...any) ([]string, error) {
 	errs = packersdk.MultiErrorAppend(errs, c.WaitIpConfig.Prepare()...)
 	errs = packersdk.MultiErrorAppend(errs, c.Comm.Prepare(&c.ctx)...)
 
+	disableWarnings, disableErrs := c.ValidateDisableIpWait(c.Comm.Type, c.Comm.Host())
+	warnings = append(warnings, disableWarnings...)
+	errs = packersdk.MultiErrorAppend(errs, disableErrs...)
+
 	_, shutdownErrs := c.ShutdownConfig.Prepare(c.Comm)
 	// shutdownWarnings, shutdownErrs := c.ShutdownConfig.Prepare(c.Comm)
 	// warnings = append(warnings, shutdownWarnings...)

--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -97,6 +97,7 @@ type FlatConfig struct {
 	WaitTimeout                     *string                                     `mapstructure:"ip_wait_timeout" cty:"ip_wait_timeout" hcl:"ip_wait_timeout"`
 	SettleTimeout                   *string                                     `mapstructure:"ip_settle_timeout" cty:"ip_settle_timeout" hcl:"ip_settle_timeout"`
 	WaitAddress                     *string                                     `mapstructure:"ip_wait_address" cty:"ip_wait_address" hcl:"ip_wait_address"`
+	DisableIpWait                   *bool                                       `mapstructure:"disable_ip_wait" cty:"disable_ip_wait" hcl:"disable_ip_wait"`
 	Type                            *string                                     `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
 	PauseBeforeConnect              *string                                     `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
 	SSHHost                         *string                                     `mapstructure:"ssh_host" cty:"ssh_host" hcl:"ssh_host"`
@@ -257,6 +258,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ip_wait_timeout":                &hcldec.AttrSpec{Name: "ip_wait_timeout", Type: cty.String, Required: false},
 		"ip_settle_timeout":              &hcldec.AttrSpec{Name: "ip_settle_timeout", Type: cty.String, Required: false},
 		"ip_wait_address":                &hcldec.AttrSpec{Name: "ip_wait_address", Type: cty.String, Required: false},
+		"disable_ip_wait":                &hcldec.AttrSpec{Name: "disable_ip_wait", Type: cty.Bool, Required: false},
 		"communicator":                   &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
 		"pause_before_connecting":        &hcldec.AttrSpec{Name: "pause_before_connecting", Type: cty.String, Required: false},
 		"ssh_host":                       &hcldec.AttrSpec{Name: "ssh_host", Type: cty.String, Required: false},

--- a/builder/vsphere/clone/config_test.go
+++ b/builder/vsphere/clone/config_test.go
@@ -38,6 +38,53 @@ func TestCloneConfig_Timeout(t *testing.T) {
 	}
 }
 
+func TestCloneConfig_DisableIpWaitRequiresHost(t *testing.T) {
+	raw := minimalConfig()
+	raw["disable_ip_wait"] = true
+	c := new(Config)
+	_, err := c.Prepare(raw)
+	testConfigErr(t, "disable_ip_wait", nil, err)
+}
+
+func TestCloneConfig_DisableIpWaitWithSSHHost(t *testing.T) {
+	raw := minimalConfig()
+	raw["disable_ip_wait"] = true
+	raw["ssh_host"] = "192.168.1.10"
+	c := new(Config)
+	warns, err := c.Prepare(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	found := false
+	for _, w := range warns {
+		if strings.Contains(w, "disable_ip_wait") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected disable_ip_wait warning, got %#v", warns)
+	}
+}
+
+func TestCloneConfig_DisableIpWaitWithCommunicatorNone(t *testing.T) {
+	raw := minimalConfig()
+	raw["disable_ip_wait"] = true
+	raw["communicator"] = "none"
+	delete(raw, "ssh_username")
+	delete(raw, "ssh_password")
+	c := new(Config)
+	warns, err := c.Prepare(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	for _, w := range warns {
+		if strings.Contains(w, "disable_ip_wait") {
+			t.Fatalf("did not expect disable_ip_wait warning with communicator none, got %#v", warns)
+		}
+	}
+}
+
 func TestCloneConfig_RAMReservation(t *testing.T) {
 	raw := minimalConfig()
 	raw["RAM_reservation"] = 1000

--- a/builder/vsphere/common/step_wait_for_ip.go
+++ b/builder/vsphere/common/step_wait_for_ip.go
@@ -33,16 +33,24 @@ type WaitIpConfig struct {
 	// documentation for full details.
 	SettleTimeout time.Duration `mapstructure:"ip_settle_timeout"`
 	// Set this to a CIDR address to cause the service to wait for an address that is contained in
-	// this network range. Defaults to `0.0.0.0/0` for any IPv4 address. Examples include:
+	// this network range. Defaults to `0.0.0.0/0` for any IPv4 address.
 	//
+	// -> **Note:** This only filters which guest-reported IP is accepted; it does not disable IP wait. Use `disable_ip_wait` to skip
+	// waiting for a guest-reported IP entirely. When `disable_ip_wait` is true, this setting still applies to HTTP IP discovery.
+	//
+	// Examples include:
 	// * empty string ("") - remove all filters
 	// * `0:0:0:0:0:0:0:0/0` - allow only ipv6 addresses
 	// * `192.168.1.0/24` - only allow ipv4 addresses from 192.168.1.1 to 192.168.1.254
 	WaitAddress *string `mapstructure:"ip_wait_address"`
 	ipnet       *net.IPNet
-
-	// WaitTimeout is a total timeout. If the virtual machine changes IP frequently, and does not settle down, wait
-	// until the timeout expires.
+	// When true, skip waiting for a guest-reported IP from vCenter. The default wait relies on
+	// VMware Tools or open-vm-tools guest information. Use when they cannot be installed during
+	// guest operating system install. Defaults to `false`.
+	//
+	// -> **Note:** You must set `ssh_host` or `winrm_host`; reachability timing uses `ssh_timeout`
+	// or `winrm_timeout`, not `ip_wait_timeout`.
+	DisableIpWait bool `mapstructure:"disable_ip_wait"`
 }
 
 type StepWaitForIp struct {
@@ -72,6 +80,26 @@ func (c *WaitIpConfig) Prepare() []error {
 	}
 
 	return errs
+}
+
+// ValidateDisableIpWait checks disable_ip_wait requirements against the communicator.
+// Validation is skipped when the communicator type is "none" because IP wait and connect
+// steps are not run in that mode.
+func (c *WaitIpConfig) ValidateDisableIpWait(commType, commHost string) ([]string, []error) {
+	if !c.DisableIpWait || commType == "none" {
+		return nil, nil
+	}
+
+	var warnings []string
+	var errs []error
+
+	if commHost == "" {
+		errs = append(errs, fmt.Errorf("disable_ip_wait is true but no ssh_host or winrm_host was set"))
+	}
+
+	warnings = append(warnings, "disable_ip_wait is set; ip_wait_timeout and ip_settle_timeout are ignored")
+
+	return warnings, errs
 }
 
 func (c *WaitIpConfig) GetIPNet() *net.IPNet {

--- a/builder/vsphere/common/step_wait_for_ip.hcl2spec.go
+++ b/builder/vsphere/common/step_wait_for_ip.hcl2spec.go
@@ -13,6 +13,7 @@ type FlatWaitIpConfig struct {
 	WaitTimeout   *string `mapstructure:"ip_wait_timeout" cty:"ip_wait_timeout" hcl:"ip_wait_timeout"`
 	SettleTimeout *string `mapstructure:"ip_settle_timeout" cty:"ip_settle_timeout" hcl:"ip_settle_timeout"`
 	WaitAddress   *string `mapstructure:"ip_wait_address" cty:"ip_wait_address" hcl:"ip_wait_address"`
+	DisableIpWait *bool   `mapstructure:"disable_ip_wait" cty:"disable_ip_wait" hcl:"disable_ip_wait"`
 }
 
 // FlatMapstructure returns a new FlatWaitIpConfig.
@@ -30,6 +31,7 @@ func (*FlatWaitIpConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ip_wait_timeout":   &hcldec.AttrSpec{Name: "ip_wait_timeout", Type: cty.String, Required: false},
 		"ip_settle_timeout": &hcldec.AttrSpec{Name: "ip_settle_timeout", Type: cty.String, Required: false},
 		"ip_wait_address":   &hcldec.AttrSpec{Name: "ip_wait_address", Type: cty.String, Required: false},
+		"disable_ip_wait":   &hcldec.AttrSpec{Name: "disable_ip_wait", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/common/step_wait_for_ip_test.go
+++ b/builder/vsphere/common/step_wait_for_ip_test.go
@@ -1,0 +1,68 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWaitIpConfig_Prepare_defaults(t *testing.T) {
+	c := &WaitIpConfig{}
+	errs := c.Prepare()
+	if len(errs) > 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if c.WaitTimeout != 30*time.Minute {
+		t.Fatalf("expected default wait timeout 30m, got %v", c.WaitTimeout)
+	}
+	if c.WaitAddress == nil || *c.WaitAddress != "0.0.0.0/0" {
+		t.Fatalf("expected default ip_wait_address 0.0.0.0/0, got %v", c.WaitAddress)
+	}
+}
+
+func TestWaitIpConfig_ValidateDisableIpWait(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		c := &WaitIpConfig{}
+		warnings, errs := c.ValidateDisableIpWait("ssh", "")
+		if len(warnings) > 0 || len(errs) > 0 {
+			t.Fatalf("expected no warnings or errors, got warnings=%v errs=%v", warnings, errs)
+		}
+	})
+
+	t.Run("requires communicator host", func(t *testing.T) {
+		c := &WaitIpConfig{DisableIpWait: true}
+		warnings, errs := c.ValidateDisableIpWait("ssh", "")
+		if len(errs) != 1 {
+			t.Fatalf("expected one error, got %v", errs)
+		}
+		if len(warnings) != 1 {
+			t.Fatalf("expected one warning, got %v", warnings)
+		}
+		if strings.Contains(warnings[0], "ip_wait_address") {
+			t.Fatalf("warning should not claim ip_wait_address is ignored: %v", warnings[0])
+		}
+	})
+
+	t.Run("ok with ssh host", func(t *testing.T) {
+		c := &WaitIpConfig{DisableIpWait: true}
+		warnings, errs := c.ValidateDisableIpWait("ssh", "192.168.1.10")
+		if len(errs) > 0 {
+			t.Fatalf("unexpected errors: %v", errs)
+		}
+		if len(warnings) != 1 || !strings.Contains(warnings[0], "disable_ip_wait") {
+			t.Fatalf("expected disable_ip_wait warning, got %v", warnings)
+		}
+	})
+
+	t.Run("skipped for communicator none", func(t *testing.T) {
+		c := &WaitIpConfig{DisableIpWait: true}
+		warnings, errs := c.ValidateDisableIpWait("none", "")
+		if len(warnings) > 0 || len(errs) > 0 {
+			t.Fatalf("expected no warnings or errors for communicator none, got warnings=%v errs=%v", warnings, errs)
+		}
+	})
+}

--- a/builder/vsphere/iso/builder.go
+++ b/builder/vsphere/iso/builder.go
@@ -178,10 +178,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	)
 
 	if b.config.Comm.Type != "none" {
-		steps = append(steps,
-			&common.StepWaitForIp{
+		if !b.config.DisableIpWait {
+			steps = append(steps, &common.StepWaitForIp{
 				Config: &b.config.WaitIpConfig,
-			},
+			})
+		}
+		steps = append(steps,
 			&communicator.StepConnect{
 				Config:    &b.config.Comm,
 				Host:      common.CommHost(b.config.Comm.Host()),

--- a/builder/vsphere/iso/config.go
+++ b/builder/vsphere/iso/config.go
@@ -127,6 +127,10 @@ func (c *Config) Prepare(raws ...any) ([]string, error) {
 	errs = packersdk.MultiErrorAppend(errs, c.Comm.Prepare(&c.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs, c.VAppConfig.PrepareSSH(c.Comm)...)
 
+	disableWarnings, disableErrs := c.ValidateDisableIpWait(c.Comm.Type, c.Comm.Host())
+	warnings = append(warnings, disableWarnings...)
+	errs = packersdk.MultiErrorAppend(errs, disableErrs...)
+
 	shutdownWarnings, shutdownErrs := c.ShutdownConfig.Prepare(c.Comm)
 	warnings = append(warnings, shutdownWarnings...)
 	errs = packersdk.MultiErrorAppend(errs, shutdownErrs...)

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -98,6 +98,7 @@ type FlatConfig struct {
 	WaitTimeout                     *string                                     `mapstructure:"ip_wait_timeout" cty:"ip_wait_timeout" hcl:"ip_wait_timeout"`
 	SettleTimeout                   *string                                     `mapstructure:"ip_settle_timeout" cty:"ip_settle_timeout" hcl:"ip_settle_timeout"`
 	WaitAddress                     *string                                     `mapstructure:"ip_wait_address" cty:"ip_wait_address" hcl:"ip_wait_address"`
+	DisableIpWait                   *bool                                       `mapstructure:"disable_ip_wait" cty:"disable_ip_wait" hcl:"disable_ip_wait"`
 	Type                            *string                                     `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
 	PauseBeforeConnect              *string                                     `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
 	SSHHost                         *string                                     `mapstructure:"ssh_host" cty:"ssh_host" hcl:"ssh_host"`
@@ -264,6 +265,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ip_wait_timeout":                &hcldec.AttrSpec{Name: "ip_wait_timeout", Type: cty.String, Required: false},
 		"ip_settle_timeout":              &hcldec.AttrSpec{Name: "ip_settle_timeout", Type: cty.String, Required: false},
 		"ip_wait_address":                &hcldec.AttrSpec{Name: "ip_wait_address", Type: cty.String, Required: false},
+		"disable_ip_wait":                &hcldec.AttrSpec{Name: "disable_ip_wait", Type: cty.Bool, Required: false},
 		"communicator":                   &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
 		"pause_before_connecting":        &hcldec.AttrSpec{Name: "pause_before_connecting", Type: cty.String, Required: false},
 		"ssh_host":                       &hcldec.AttrSpec{Name: "ssh_host", Type: cty.String, Required: false},

--- a/builder/vsphere/iso/config_test.go
+++ b/builder/vsphere/iso/config_test.go
@@ -1,0 +1,77 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package iso
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestISOConfig_DisableIpWaitRequiresHost(t *testing.T) {
+	raw := minimalISOConfig()
+	raw["disable_ip_wait"] = true
+	c := new(Config)
+	_, err := c.Prepare(raw)
+	if err == nil {
+		t.Fatal("expected disable_ip_wait error when ssh_host/winrm_host is unset")
+	}
+	if !strings.Contains(err.Error(), "disable_ip_wait") {
+		t.Fatalf("expected disable_ip_wait error, got: %s", err)
+	}
+}
+
+func TestISOConfig_DisableIpWaitWithSSHHost(t *testing.T) {
+	raw := minimalISOConfig()
+	raw["disable_ip_wait"] = true
+	raw["ssh_host"] = "192.168.1.10"
+	c := new(Config)
+	warns, err := c.Prepare(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	found := false
+	for _, w := range warns {
+		if strings.Contains(w, "disable_ip_wait") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected disable_ip_wait warning, got %#v", warns)
+	}
+}
+
+func TestISOConfig_DisableIpWaitWithCommunicatorNone(t *testing.T) {
+	raw := minimalISOConfig()
+	raw["disable_ip_wait"] = true
+	raw["communicator"] = "none"
+	delete(raw, "ssh_username")
+	delete(raw, "ssh_password")
+	c := new(Config)
+	warns, err := c.Prepare(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	for _, w := range warns {
+		if strings.Contains(w, "disable_ip_wait") {
+			t.Fatalf("did not expect disable_ip_wait warning with communicator none, got %#v", warns)
+		}
+	}
+}
+
+func minimalISOConfig() map[string]any {
+	return map[string]any{
+		"vcenter_server": "vc01.example.com",
+		"username":       "administrator@vsphere.local",
+		"password":       "VMw@re1!",
+		"vm_name":        "vm-01",
+		"host":           "esx01.example.com",
+		"storage": map[string]any{
+			"disk_size": 1024,
+		},
+		"ssh_username": "root",
+		"ssh_password": "VMw@re1!",
+	}
+}

--- a/docs-partials/builder/vsphere/common/WaitIpConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/WaitIpConfig-not-required.mdx
@@ -13,10 +13,21 @@
   documentation for full details.
 
 - `ip_wait_address` (\*string) - Set this to a CIDR address to cause the service to wait for an address that is contained in
-  this network range. Defaults to `0.0.0.0/0` for any IPv4 address. Examples include:
+  this network range. Defaults to `0.0.0.0/0` for any IPv4 address.
   
+  -> **Note:** This only filters which guest-reported IP is accepted; it does not disable IP wait. Use `disable_ip_wait` to skip
+  waiting for a guest-reported IP entirely. When `disable_ip_wait` is true, this setting still applies to HTTP IP discovery.
+  
+  Examples include:
   * empty string ("") - remove all filters
   * `0:0:0:0:0:0:0:0/0` - allow only ipv6 addresses
   * `192.168.1.0/24` - only allow ipv4 addresses from 192.168.1.1 to 192.168.1.254
+
+- `disable_ip_wait` (bool) - When true, skip waiting for a guest-reported IP from vCenter. The default wait relies on
+  VMware Tools or open-vm-tools guest information. Use when they cannot be installed during
+  guest operating system install. Defaults to `false`.
+  
+  -> **Note:** You must set `ssh_host` or `winrm_host`; reachability timing uses `ssh_timeout`
+  or `winrm_timeout`, not `ip_wait_timeout`.
 
 <!-- End of code generated from the comments of the WaitIpConfig struct in builder/vsphere/common/step_wait_for_ip.go; -->


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

Adds the `disable_ip_wait` option (`vsphere-iso` and `vsphere-clone`) to allow skipping the guest-reported IP wait when VMware Tools / open-vm-tools are unavailable.

Note: You must set `ssh_host` or `winrm_host`; reachability timing uses `ssh_timeout` or `winrm_timeout`, not `ip_wait_timeout`.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [x] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been added or updated.
- [x] Tests have been completed.

`alpine-disable-ip-wait/alpine.pkr.hcl`

The guest gets a static address via answerfile (default 192.168.86.241). Packer connects
with `ssh_host`; reachability timing uses `ssh_timeout`, not `ip_wait_timeout`.

The `shutdown_command` is required because `open-vm-tools` is not installed (Tools guest power-off would fail with "VMware Tools is not running")

```hcl
// Example: skip guest-reported IP wait when VMware Tools / open-vm-tools are unavailable.
//
// Minimum Version: Alpine Linux 3.23.4
// alpine-standard-<version>-x86_64.iso
//
// Usage:
//   packer build .
//   packer build -var 'ssh_host=192.168.86.241' .

packer {
  required_plugins {
    vsphere = {
      version = "~> 1"
      source  = "github.com/vmware/vsphere"
    }
  }
}

variable "alpine_version" {
  type        = string
  default     = "3.23.4"
  description = "The version of Alpine Linux to be used."
}

variable "vm_name_prefix" {
  type        = string
  default     = "alpine-no-tools"
  description = "Prefix for naming the virtual machine."
}

variable "guest_os_type" {
  type        = string
  default     = "other6xLinux64Guest"
  description = "The type of guest OS to configure for the virtual machine."
}

variable "username" {
  type        = string
  default     = "administrator@vsphere.local"
  sensitive   = true
  description = "The username for authenticating with the vCenter instance."
}

variable "password" {
  type        = string
  default     = "VMw@re1!"
  sensitive   = true
  description = "The password for authenticating with the vCenter instance."
}

variable "vcenter_server" {
  type        = string
  default     = "vc01.example.com"
  description = "The vCenter instance used for managing the ESX host."
}

variable "host" {
  type        = string
  default     = "esx01.example.com"
  description = "The ESX host where the virtual machine will be built."
}

variable "insecure_connection" {
  type        = bool
  default     = true
  description = "Set to true to allow insecure connections to the vCenter instance."
}

variable "vm_version" {
  type        = string
  default     = "21"
  description = "The virtual hardware version to use for the virtual machine."
}

variable "root_password" {
  type        = string
  default     = "VMw@re1!"
  sensitive   = true
  description = "The root password for the virtual machine."
}

variable "ssh_username" {
  type        = string
  default     = "root"
  description = "The SSH username for the virtual machine."
}

variable "ssh_host" {
  type        = string
  default     = "192.168.86.241"
  description = "Required with disable_ip_wait. Must match the static address in answerfile."
}

variable "ssh_timeout" {
  type        = string
  default     = "30m"
  description = "How long to wait for SSH when disable_ip_wait is true."
}

variable "datastore" {
  type        = string
  default     = "local-ssd01-esx01"
  description = "The ESX datastore where the ISO and virtual machine will be stored."
}

variable "datastore_path" {
  type        = string
  default     = "iso"
  description = "The path within the datastore that contains the ISO file."
}

variable "cpus" {
  type        = number
  default     = 1
  description = "Number of CPUs to assign to the virtual machine."
}

variable "ram" {
  type        = number
  default     = 512
  description = "Amount of RAM (in MB) to assign to the virtual machine."
}

variable "network_name" {
  type        = string
  default     = "VM Network"
  description = "The network name to attach the virtual machine to."
}

variable "disk_size" {
  type        = number
  default     = 1024
  description = "Size of the disk (in MB) to allocate for the virtual machine."
}

variable "disk_controller_type" {
  type        = list(string)
  default     = ["pvscsi"]
  description = "The type of storage controller to use for virtual machine disks."
}

variable "network_card" {
  type        = string
  default     = "vmxnet3"
  description = "The type of network card to use for the virtual machine."
}

locals {
  iso_path  = "[${var.datastore}] ${var.datastore_path}/linux/alpine/3/amd64/alpine-standard-${var.alpine_version}-x86_64.iso"
  timestamp = regex_replace(timestamp(), "[- TZ:]", "")
}

source "vsphere-iso" "example" {
  username            = var.username
  password            = var.password
  vcenter_server      = var.vcenter_server
  host                = var.host
  insecure_connection = var.insecure_connection
  vm_version          = var.vm_version
  vm_name             = "${var.vm_name_prefix}-${local.timestamp}"
  ssh_username        = var.ssh_username
  ssh_password        = var.root_password
  ssh_host            = var.ssh_host
  ssh_timeout         = var.ssh_timeout
  disable_ip_wait     = true
  shutdown_command    = "/usr/local/bin/shutdown"
  iso_paths           = [local.iso_path]
  floppy_files        = ["${path.root}/answerfile", "${path.root}/setup.sh"]
  guest_os_type       = var.guest_os_type
  CPUs                = var.cpus
  RAM                 = var.ram
  boot_command = [
    "<wait30>",
    "root<enter><wait>",
    "mount -t vfat /dev/fd0 /media/floppy<enter><wait>",
    "setup-alpine -f /media/floppy/answerfile<enter>",
    "<wait20>",
    "${var.root_password}<enter>",
    "${var.root_password}<enter>",
    "<wait5>",
    "y<enter>",
    "<wait20>",
    "reboot<enter>",
    "<wait20>",
    "root<enter>",
    "${var.root_password}<enter><wait>",
    "mount -t vfat /dev/fd0 /media/floppy<enter><wait>",
    "/media/floppy/SETUP.SH<enter>"
  ]
  boot_wait = "15s"
  network_adapters {
    network_card = var.network_card
    network      = var.network_name
  }
  storage {
    disk_size             = var.disk_size
    disk_thin_provisioned = true
  }
  disk_controller_type = var.disk_controller_type
  datastore            = var.datastore
}

build {
  sources = ["source.vsphere-iso.example"]

  provisioner "shell" {
    inline = ["ls /"]
  }
}
```

`answerfile` (Includes the IP Configuration)

```text
KEYMAPOPTS="us us"
HOSTNAMEOPTS="-n alpine"
DEVDOPTS=mdev
INTERFACESOPTS="auto lo
iface lo inet loopback

auto eth0
iface eth0 inet static
	address 192.168.86.241
	netmask 255.255.255.0
	gateway 192.168.86.1
hostname alpine
"
DNSOPTS="-d local -n 192.168.86.1"
TIMEZONEOPTS="-z UTC"
PROXYOPTS="none"
APKREPOSOPTS="-1"
USEROPTS="-a -u packer"
SSHDOPTS="openssh"
NTPOPTS="none"
DISKOPTS="-m sys /dev/sda"
```

`setup.sh`

```text
#!/bin/sh
# Minimal post-install setup for the disable_ip_wait example.
# Intentionally does not install open-vm-tools so vCenter cannot report a guest IP.
# Floppy VFAT exposes this as SETUP.SH (same as the standard alpine example).

set -ex

sed -i 's/#http/http/' /etc/apk/repositories

# Retry package index fetch before continuing (network may lag after reboot).
i=0
while [ "$i" -lt 12 ]; do
	if apk update; then
		break
	fi
	i=$((i + 1))
	sleep 5
done
apk update

cat >/usr/local/bin/shutdown <<EOF
#!/bin/sh
poweroff
EOF
chmod +x /usr/local/bin/shutdown

sed -i "/#PermitRootLogin/c\PermitRootLogin yes" /etc/ssh/sshd_config
/etc/init.d/sshd restart
```

Result:

```sh
cd alpine-disable-ip-wait
➜ packer build .
vsphere-iso.example: output will be in this color.

==> vsphere-iso.example: Creating virtual machine...
==> vsphere-iso.example: Applying custom hardware configuration...
==> vsphere-iso.example: Mounting ISO images...
==> vsphere-iso.example: Adding configuration parameters...
==> vsphere-iso.example: Creating floppy disk...
==> vsphere-iso.example: Copying files flatly from floppy_files
==> vsphere-iso.example: Copying file: ./answerfile
==> vsphere-iso.example: Copying file: ./setup.sh
==> vsphere-iso.example: Done copying files from floppy_files
==> vsphere-iso.example: Collecting paths from floppy_dirs
==> vsphere-iso.example: Resulting paths from floppy_dirs : []
==> vsphere-iso.example: Done copying paths from floppy_dirs
==> vsphere-iso.example: Copying files from floppy_content
==> vsphere-iso.example: Done copying files from floppy_content
==> vsphere-iso.example: Uploading floppy image...
==> vsphere-iso.example: Adding generated floppy image...
==> vsphere-iso.example: Setting temporary boot order...
==> vsphere-iso.example: Powering on virtual machine...
==> vsphere-iso.example: Waiting 15s for boot...
==> vsphere-iso.example: Typing boot command...
==> vsphere-iso.example: Using SSH communicator to connect: 192.168.86.241
==> vsphere-iso.example: Waiting for SSH to become available...
==> vsphere-iso.example: Connected to SSH!
==> vsphere-iso.example: Provisioning with shell script: /var/folders/89/7szw2xb93m5dylqgdt9d62bc0000gn/T/packer-shell3414066181
==> vsphere-iso.example: bin
==> vsphere-iso.example: boot
==> vsphere-iso.example: dev
==> vsphere-iso.example: etc
==> vsphere-iso.example: home
==> vsphere-iso.example: lib
==> vsphere-iso.example: lost+found
==> vsphere-iso.example: media
==> vsphere-iso.example: mnt
==> vsphere-iso.example: opt
==> vsphere-iso.example: proc
==> vsphere-iso.example: root
==> vsphere-iso.example: run
==> vsphere-iso.example: sbin
==> vsphere-iso.example: srv
==> vsphere-iso.example: sys
==> vsphere-iso.example: tmp
==> vsphere-iso.example: usr
==> vsphere-iso.example: var
==> vsphere-iso.example: Running shutdown command...
==> vsphere-iso.example: Deleting floppy drives...
==> vsphere-iso.example: Deleting floppy image...
==> vsphere-iso.example: Ejecting CD-ROM media...
==> vsphere-iso.example: Clearing boot order...
==> vsphere-iso.example: Closing sessions...
Build 'vsphere-iso.example' finished after 2 minutes 33 seconds.

==> Wait completed after 2 minutes 33 seconds

==> Builds finished. The artifacts of successful builds are:
--> vsphere-iso.example: alpine-no-tools-20260812201120
```

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [x] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

Closes #669

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->