### PR TITLE
fix: do not require all nics to have an ip

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -353,8 +353,8 @@ disks are stored.
 - `disk_eagerly_scrub` (bool) - Enable eager scrubbing for the disk.
   Defaults to `false`.
 
-- `disk_controller_index` (int) - The assigned disk controller for the disk.
-  Defaults to the first controller, `(0)`.
+- `disk_controller_index` (int) - The assigned disk controller for the disk at the zero-based index
+  (0, 1, 2, ...). Defaults to the first controller, `(0)`.
   Mutually exclusive with `disk_controller_unit`.
 
 - `disk_controller_unit` (string) - Explicit controller address for the disk when cloning from a `template`
@@ -1597,35 +1597,42 @@ wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/foo/bar/preseed.cfg
 
 <!-- Code generated from the comments of the WaitIpConfig struct in builder/vsphere/common/step_wait_for_ip.go; DO NOT EDIT MANUALLY -->
 
-- `ip_wait_timeout` (duration string | ex: "1h5m2s") - Amount of time to wait for VM's IP, similar to 'ssh_timeout'.
-  Defaults to `30m` (30 minutes). Refer to the Golang
+- `ip_wait_timeout` (duration string | ex: "1h5m2s") - The amount of time to wait for virtual machine's IP, similar to
+  `ssh_timeout`. Defaults to `30m` (30 minutes). Refer to the Golang
   [ParseDuration](https://golang.org/pkg/time/#ParseDuration)
-  documentation for full details.
+  documentation for more information.
 
-- `ip_settle_timeout` (duration string | ex: "1h5m2s") - Amount of time to wait for VM's IP to settle down, sometimes VM may
-  report incorrect IP initially, then it is recommended to set that
-  parameter to apx. 2 minutes. Examples `45s` and `10m`.
-  Defaults to `5s` (5 seconds). Refer to the Golang
-  [ParseDuration](https://golang.org/pkg/time/#ParseDuration)
-  documentation for full details.
+- `ip_settle_timeout` (duration string | ex: "1h5m2s") - The amount of time to wait for virtual machine's IP to settle down. For
+  example, `45s` and `10m`. Defaults to `5s` (5 seconds). Refer to the
+  Golang [ParseDuration](https://golang.org/pkg/time/#ParseDuration)
+  documentation for more information.
 
-- `ip_wait_address` (\*string) - Set this to a CIDR address to cause the service to wait for an address that is contained in
-  this network range. Defaults to `0.0.0.0/0` for any IPv4 address.
+- `ip_wait_address` (\*string) - The IP address range in CIDR notation to wait for. Defaults to
+  `0.0.0.0/0` for any IPv4 address.
   
-  -> **Note:** This only filters which guest-reported IP is accepted; it does not disable IP wait. Use `disable_ip_wait` to skip
-  waiting for a guest-reported IP entirely. When `disable_ip_wait` is true, this setting still applies to HTTP IP discovery.
+  -> **Note:** This only filters which guest-reported IP is accepted; it
+  does not disable IP wait. Use `disable_ip_wait` to skip waiting for a
+  guest-reported IP entirely. When `disable_ip_wait` is `true`, this
+  setting still applies to HTTP IP discovery.
   
   Examples include:
   * empty string ("") - remove all filters
-  * `0:0:0:0:0:0:0:0/0` - allow only ipv6 addresses
-  * `192.168.1.0/24` - only allow ipv4 addresses from 192.168.1.1 to 192.168.1.254
+  * `0:0:0:0:0:0:0:0/0` - allow only IPv6 addresses
+  * `192.168.1.0/24` - only allow IPv4 addresses from 192.168.1.1 to 192.168.1.254
 
-- `disable_ip_wait` (bool) - When true, skip waiting for a guest-reported IP from vCenter. The default wait relies on
-  VMware Tools or open-vm-tools guest information. Use when they cannot be installed during
-  guest operating system install. Defaults to `false`.
+- `ip_wait_adapter_index` (\*int) - When set, wait for an IP on a specific network adapter at this zero-based
+  index (0, 1, 2, ...). For `vsphere-iso`, the index follows
+  `network_adapters` order (the first block is `0`). For `vsphere-clone`,
+  the index follows the order the adapters were added on the source virtual
+  machine.
+
+- `disable_ip_wait` (bool) - When `true`, skip waiting for a guest-reported IP from vCenter. The
+  default wait relies on VMware Tools or open-vm-tools guest information.
+  Use when they cannot be installed during guest operating system install.
+  Defaults to `false`.
   
-  -> **Note:** You must set `ssh_host` or `winrm_host`; reachability timing uses `ssh_timeout`
-  or `winrm_timeout`, not `ip_wait_timeout`.
+  -> **Note:** You must set `ssh_host` or `winrm_host`; reachability timing
+  uses `ssh_timeout` or `winrm_timeout`, not `ip_wait_timeout`.
 
 <!-- End of code generated from the comments of the WaitIpConfig struct in builder/vsphere/common/step_wait_for_ip.go; -->
 

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -877,8 +877,8 @@ JSON Example:
 - `disk_eagerly_scrub` (bool) - Enable eager scrubbing for the disk.
   Defaults to `false`.
 
-- `disk_controller_index` (int) - The assigned disk controller for the disk.
-  Defaults to the first controller, `(0)`.
+- `disk_controller_index` (int) - The assigned disk controller for the disk at the zero-based index
+  (0, 1, 2, ...). Defaults to the first controller, `(0)`.
   Mutually exclusive with `disk_controller_unit`.
 
 - `disk_controller_unit` (string) - Explicit controller address for the disk when cloning from a `template`
@@ -1212,35 +1212,42 @@ JSON Example:
 
 <!-- Code generated from the comments of the WaitIpConfig struct in builder/vsphere/common/step_wait_for_ip.go; DO NOT EDIT MANUALLY -->
 
-- `ip_wait_timeout` (duration string | ex: "1h5m2s") - Amount of time to wait for VM's IP, similar to 'ssh_timeout'.
-  Defaults to `30m` (30 minutes). Refer to the Golang
+- `ip_wait_timeout` (duration string | ex: "1h5m2s") - The amount of time to wait for virtual machine's IP, similar to
+  `ssh_timeout`. Defaults to `30m` (30 minutes). Refer to the Golang
   [ParseDuration](https://golang.org/pkg/time/#ParseDuration)
-  documentation for full details.
+  documentation for more information.
 
-- `ip_settle_timeout` (duration string | ex: "1h5m2s") - Amount of time to wait for VM's IP to settle down, sometimes VM may
-  report incorrect IP initially, then it is recommended to set that
-  parameter to apx. 2 minutes. Examples `45s` and `10m`.
-  Defaults to `5s` (5 seconds). Refer to the Golang
-  [ParseDuration](https://golang.org/pkg/time/#ParseDuration)
-  documentation for full details.
+- `ip_settle_timeout` (duration string | ex: "1h5m2s") - The amount of time to wait for virtual machine's IP to settle down. For
+  example, `45s` and `10m`. Defaults to `5s` (5 seconds). Refer to the
+  Golang [ParseDuration](https://golang.org/pkg/time/#ParseDuration)
+  documentation for more information.
 
-- `ip_wait_address` (\*string) - Set this to a CIDR address to cause the service to wait for an address that is contained in
-  this network range. Defaults to `0.0.0.0/0` for any IPv4 address.
+- `ip_wait_address` (\*string) - The IP address range in CIDR notation to wait for. Defaults to
+  `0.0.0.0/0` for any IPv4 address.
   
-  -> **Note:** This only filters which guest-reported IP is accepted; it does not disable IP wait. Use `disable_ip_wait` to skip
-  waiting for a guest-reported IP entirely. When `disable_ip_wait` is true, this setting still applies to HTTP IP discovery.
+  -> **Note:** This only filters which guest-reported IP is accepted; it
+  does not disable IP wait. Use `disable_ip_wait` to skip waiting for a
+  guest-reported IP entirely. When `disable_ip_wait` is `true`, this
+  setting still applies to HTTP IP discovery.
   
   Examples include:
   * empty string ("") - remove all filters
-  * `0:0:0:0:0:0:0:0/0` - allow only ipv6 addresses
-  * `192.168.1.0/24` - only allow ipv4 addresses from 192.168.1.1 to 192.168.1.254
+  * `0:0:0:0:0:0:0:0/0` - allow only IPv6 addresses
+  * `192.168.1.0/24` - only allow IPv4 addresses from 192.168.1.1 to 192.168.1.254
 
-- `disable_ip_wait` (bool) - When true, skip waiting for a guest-reported IP from vCenter. The default wait relies on
-  VMware Tools or open-vm-tools guest information. Use when they cannot be installed during
-  guest operating system install. Defaults to `false`.
+- `ip_wait_adapter_index` (\*int) - When set, wait for an IP on a specific network adapter at this zero-based
+  index (0, 1, 2, ...). For `vsphere-iso`, the index follows
+  `network_adapters` order (the first block is `0`). For `vsphere-clone`,
+  the index follows the order the adapters were added on the source virtual
+  machine.
+
+- `disable_ip_wait` (bool) - When `true`, skip waiting for a guest-reported IP from vCenter. The
+  default wait relies on VMware Tools or open-vm-tools guest information.
+  Use when they cannot be installed during guest operating system install.
+  Defaults to `false`.
   
-  -> **Note:** You must set `ssh_host` or `winrm_host`; reachability timing uses `ssh_timeout`
-  or `winrm_timeout`, not `ip_wait_timeout`.
+  -> **Note:** You must set `ssh_host` or `winrm_host`; reachability timing
+  uses `ssh_timeout` or `winrm_timeout`, not `ip_wait_timeout`.
 
 <!-- End of code generated from the comments of the WaitIpConfig struct in builder/vsphere/common/step_wait_for_ip.go; -->
 

--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -98,6 +98,7 @@ type FlatConfig struct {
 	WaitTimeout                     *string                                     `mapstructure:"ip_wait_timeout" cty:"ip_wait_timeout" hcl:"ip_wait_timeout"`
 	SettleTimeout                   *string                                     `mapstructure:"ip_settle_timeout" cty:"ip_settle_timeout" hcl:"ip_settle_timeout"`
 	WaitAddress                     *string                                     `mapstructure:"ip_wait_address" cty:"ip_wait_address" hcl:"ip_wait_address"`
+	WaitAdapterIndex                *int                                        `mapstructure:"ip_wait_adapter_index" cty:"ip_wait_adapter_index" hcl:"ip_wait_adapter_index"`
 	DisableIpWait                   *bool                                       `mapstructure:"disable_ip_wait" cty:"disable_ip_wait" hcl:"disable_ip_wait"`
 	Type                            *string                                     `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
 	PauseBeforeConnect              *string                                     `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
@@ -260,6 +261,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ip_wait_timeout":                &hcldec.AttrSpec{Name: "ip_wait_timeout", Type: cty.String, Required: false},
 		"ip_settle_timeout":              &hcldec.AttrSpec{Name: "ip_settle_timeout", Type: cty.String, Required: false},
 		"ip_wait_address":                &hcldec.AttrSpec{Name: "ip_wait_address", Type: cty.String, Required: false},
+		"ip_wait_adapter_index":          &hcldec.AttrSpec{Name: "ip_wait_adapter_index", Type: cty.Number, Required: false},
 		"disable_ip_wait":                &hcldec.AttrSpec{Name: "disable_ip_wait", Type: cty.Bool, Required: false},
 		"communicator":                   &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
 		"pause_before_connecting":        &hcldec.AttrSpec{Name: "pause_before_connecting", Type: cty.String, Required: false},

--- a/builder/vsphere/common/step_wait_for_ip.go
+++ b/builder/vsphere/common/step_wait_for_ip.go
@@ -20,36 +20,43 @@ import (
 )
 
 type WaitIpConfig struct {
-	// Amount of time to wait for VM's IP, similar to 'ssh_timeout'.
-	// Defaults to `30m` (30 minutes). Refer to the Golang
+	// The amount of time to wait for virtual machine's IP, similar to
+	// `ssh_timeout`. Defaults to `30m` (30 minutes). Refer to the Golang
 	// [ParseDuration](https://golang.org/pkg/time/#ParseDuration)
-	// documentation for full details.
+	// documentation for more information.
 	WaitTimeout time.Duration `mapstructure:"ip_wait_timeout"`
-	// Amount of time to wait for VM's IP to settle down, sometimes VM may
-	// report incorrect IP initially, then it is recommended to set that
-	// parameter to apx. 2 minutes. Examples `45s` and `10m`.
-	// Defaults to `5s` (5 seconds). Refer to the Golang
-	// [ParseDuration](https://golang.org/pkg/time/#ParseDuration)
-	// documentation for full details.
+	// The amount of time to wait for virtual machine's IP to settle down. For
+	// example, `45s` and `10m`. Defaults to `5s` (5 seconds). Refer to the
+	// Golang [ParseDuration](https://golang.org/pkg/time/#ParseDuration)
+	// documentation for more information.
 	SettleTimeout time.Duration `mapstructure:"ip_settle_timeout"`
-	// Set this to a CIDR address to cause the service to wait for an address that is contained in
-	// this network range. Defaults to `0.0.0.0/0` for any IPv4 address.
+	// The IP address range in CIDR notation to wait for. Defaults to
+	// `0.0.0.0/0` for any IPv4 address.
 	//
-	// -> **Note:** This only filters which guest-reported IP is accepted; it does not disable IP wait. Use `disable_ip_wait` to skip
-	// waiting for a guest-reported IP entirely. When `disable_ip_wait` is true, this setting still applies to HTTP IP discovery.
+	// -> **Note:** This only filters which guest-reported IP is accepted; it
+	// does not disable IP wait. Use `disable_ip_wait` to skip waiting for a
+	// guest-reported IP entirely. When `disable_ip_wait` is `true`, this
+	// setting still applies to HTTP IP discovery.
 	//
 	// Examples include:
 	// * empty string ("") - remove all filters
-	// * `0:0:0:0:0:0:0:0/0` - allow only ipv6 addresses
-	// * `192.168.1.0/24` - only allow ipv4 addresses from 192.168.1.1 to 192.168.1.254
+	// * `0:0:0:0:0:0:0:0/0` - allow only IPv6 addresses
+	// * `192.168.1.0/24` - only allow IPv4 addresses from 192.168.1.1 to 192.168.1.254
 	WaitAddress *string `mapstructure:"ip_wait_address"`
 	ipnet       *net.IPNet
-	// When true, skip waiting for a guest-reported IP from vCenter. The default wait relies on
-	// VMware Tools or open-vm-tools guest information. Use when they cannot be installed during
-	// guest operating system install. Defaults to `false`.
+	// When set, wait for an IP on a specific network adapter at this zero-based
+	// index (0, 1, 2, ...). For `vsphere-iso`, the index follows
+	// `network_adapters` order (the first block is `0`). For `vsphere-clone`,
+	// the index follows the order the adapters were added on the source virtual
+	// machine.
+	WaitAdapterIndex *int `mapstructure:"ip_wait_adapter_index"`
+	// When `true`, skip waiting for a guest-reported IP from vCenter. The
+	// default wait relies on VMware Tools or open-vm-tools guest information.
+	// Use when they cannot be installed during guest operating system install.
+	// Defaults to `false`.
 	//
-	// -> **Note:** You must set `ssh_host` or `winrm_host`; reachability timing uses `ssh_timeout`
-	// or `winrm_timeout`, not `ip_wait_timeout`.
+	// -> **Note:** You must set `ssh_host` or `winrm_host`; reachability timing
+	// uses `ssh_timeout` or `winrm_timeout`, not `ip_wait_timeout`.
 	DisableIpWait bool `mapstructure:"disable_ip_wait"`
 }
 
@@ -77,6 +84,10 @@ func (c *WaitIpConfig) Prepare() []error {
 		if err != nil {
 			errs = append(errs, fmt.Errorf("unable to parse \"ip_wait_address\": %w", err))
 		}
+	}
+
+	if c.WaitAdapterIndex != nil && *c.WaitAdapterIndex < 0 {
+		errs = append(errs, fmt.Errorf("ip_wait_adapter_index must be >= 0"))
 	}
 
 	return errs
@@ -115,7 +126,24 @@ func (s *StepWaitForIp) Run(ctx context.Context, state multistep.StateBag) multi
 	}()
 
 	go func() {
-		ui.Say("Waiting for IP...")
+		if s.Config.WaitAdapterIndex != nil {
+			adapters, lookupErr := vm.NetworkAdapters(sub)
+			if lookupErr != nil {
+				err = lookupErr
+				waitDone <- true
+				return
+			}
+			i := *s.Config.WaitAdapterIndex
+			if i >= len(adapters) {
+				err = driver.AdapterIndexOutOfRangeError(i, len(adapters), "network adapters")
+				waitDone <- true
+				return
+			}
+			ui.Say("Waiting for IP on specified network adapter...")
+			log.Printf("[INFO] Waiting for IP on specified network adapter at index %d (MAC: %s)", i, adapters[i].MAC)
+		} else {
+			ui.Say("Waiting for IP...")
+		}
 		ip, err = doGetIp(vm, sub, s.Config)
 		waitDone <- true
 	}()
@@ -170,7 +198,7 @@ func doGetIp(vm *driver.VirtualMachineDriver, ctx context.Context, c *WaitIpConf
 		interval = 1 * time.Second
 	}
 loop:
-	ip, err := vm.WaitForIP(ctx, c.ipnet)
+	ip, err := vm.WaitForIP(ctx, c.ipnet, c.WaitAdapterIndex)
 	if err != nil {
 		return "", err
 	}
@@ -180,6 +208,15 @@ loop:
 	case <-ctx.Done():
 		return ip, fmt.Errorf("cancelled waiting for IP address")
 	default:
+	}
+
+	if ip == "" {
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("IP wait cancelled")
+		case <-time.After(interval):
+			goto loop
+		}
 	}
 
 	if prevIp == "" || prevIp != ip {

--- a/builder/vsphere/common/step_wait_for_ip.hcl2spec.go
+++ b/builder/vsphere/common/step_wait_for_ip.hcl2spec.go
@@ -10,10 +10,11 @@ import (
 // FlatWaitIpConfig is an auto-generated flat version of WaitIpConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatWaitIpConfig struct {
-	WaitTimeout   *string `mapstructure:"ip_wait_timeout" cty:"ip_wait_timeout" hcl:"ip_wait_timeout"`
-	SettleTimeout *string `mapstructure:"ip_settle_timeout" cty:"ip_settle_timeout" hcl:"ip_settle_timeout"`
-	WaitAddress   *string `mapstructure:"ip_wait_address" cty:"ip_wait_address" hcl:"ip_wait_address"`
-	DisableIpWait *bool   `mapstructure:"disable_ip_wait" cty:"disable_ip_wait" hcl:"disable_ip_wait"`
+	WaitTimeout      *string `mapstructure:"ip_wait_timeout" cty:"ip_wait_timeout" hcl:"ip_wait_timeout"`
+	SettleTimeout    *string `mapstructure:"ip_settle_timeout" cty:"ip_settle_timeout" hcl:"ip_settle_timeout"`
+	WaitAddress      *string `mapstructure:"ip_wait_address" cty:"ip_wait_address" hcl:"ip_wait_address"`
+	WaitAdapterIndex *int    `mapstructure:"ip_wait_adapter_index" cty:"ip_wait_adapter_index" hcl:"ip_wait_adapter_index"`
+	DisableIpWait    *bool   `mapstructure:"disable_ip_wait" cty:"disable_ip_wait" hcl:"disable_ip_wait"`
 }
 
 // FlatMapstructure returns a new FlatWaitIpConfig.
@@ -28,10 +29,11 @@ func (*WaitIpConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.
 // The decoded values from this spec will then be applied to a FlatWaitIpConfig.
 func (*FlatWaitIpConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"ip_wait_timeout":   &hcldec.AttrSpec{Name: "ip_wait_timeout", Type: cty.String, Required: false},
-		"ip_settle_timeout": &hcldec.AttrSpec{Name: "ip_settle_timeout", Type: cty.String, Required: false},
-		"ip_wait_address":   &hcldec.AttrSpec{Name: "ip_wait_address", Type: cty.String, Required: false},
-		"disable_ip_wait":   &hcldec.AttrSpec{Name: "disable_ip_wait", Type: cty.Bool, Required: false},
+		"ip_wait_timeout":       &hcldec.AttrSpec{Name: "ip_wait_timeout", Type: cty.String, Required: false},
+		"ip_settle_timeout":     &hcldec.AttrSpec{Name: "ip_settle_timeout", Type: cty.String, Required: false},
+		"ip_wait_address":       &hcldec.AttrSpec{Name: "ip_wait_address", Type: cty.String, Required: false},
+		"ip_wait_adapter_index": &hcldec.AttrSpec{Name: "ip_wait_adapter_index", Type: cty.Number, Required: false},
+		"disable_ip_wait":       &hcldec.AttrSpec{Name: "disable_ip_wait", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/common/step_wait_for_ip_test.go
+++ b/builder/vsphere/common/step_wait_for_ip_test.go
@@ -7,6 +7,8 @@ package common
 import (
 	"testing"
 	"time"
+
+	"github.com/vmware/packer-plugin-vsphere/builder/vsphere/driver"
 )
 
 func TestWaitIpConfig_Prepare_defaults(t *testing.T) {
@@ -61,4 +63,27 @@ func TestWaitIpConfig_ValidateDisableIpWait(t *testing.T) {
 			t.Fatalf("expected no warnings or errors for communicator none, got warnings=%v errs=%v", warnings, errs)
 		}
 	})
+}
+
+func TestWaitIpConfig_Prepare_adapterIndex(t *testing.T) {
+	neg := -1
+	c := WaitIpConfig{WaitAdapterIndex: &neg}
+	errs := c.Prepare()
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %v", errs)
+	}
+
+	zero := 0
+	c = WaitIpConfig{WaitAdapterIndex: &zero}
+	if errs := c.Prepare(); len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+}
+
+func TestAdapterIndexOutOfRangeError(t *testing.T) {
+	err := driver.AdapterIndexOutOfRangeError(18, 4, "network adapters")
+	want := "ip_wait_adapter_index is 18; valid indexes are 0 to 3 (4 network adapters)"
+	if err.Error() != want {
+		t.Fatalf("got %q, want %q", err.Error(), want)
+	}
 }

--- a/builder/vsphere/common/storage_config.go
+++ b/builder/vsphere/common/storage_config.go
@@ -20,8 +20,8 @@ type DiskConfig struct {
 	// Enable eager scrubbing for the disk.
 	// Defaults to `false`.
 	DiskEagerlyScrub bool `mapstructure:"disk_eagerly_scrub"`
-	// The assigned disk controller for the disk.
-	// Defaults to the first controller, `(0)`.
+	// The assigned disk controller for the disk at the zero-based index
+	// (0, 1, 2, ...). Defaults to the first controller, `(0)`.
 	// Mutually exclusive with `disk_controller_unit`.
 	DiskControllerIndex int `mapstructure:"disk_controller_index"`
 	// Explicit controller address for the disk when cloning from a `template`

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -41,7 +42,7 @@ type VirtualMachine interface {
 	Reconfigure(spec types.VirtualMachineConfigSpec) error
 	Customize(spec types.CustomizationSpec) error
 	ResizeDisk(diskSize int64) ([]types.BaseVirtualDeviceConfigSpec, error)
-	WaitForIP(ctx context.Context, ipNet *net.IPNet) (string, error)
+	WaitForIP(ctx context.Context, ipNet *net.IPNet, adapterIndex *int) (string, error)
 	PowerOn() error
 	PowerOff() error
 	IsPoweredOff() (bool, error)
@@ -821,30 +822,178 @@ func (vm *VirtualMachineDriver) PowerOn() error {
 	return err
 }
 
-// WaitForIP waits for the virtual machine to get an IP address.
-func (vm *VirtualMachineDriver) WaitForIP(ctx context.Context, ipNet *net.IPNet) (string, error) {
-	netIP, err := vm.vm.WaitForNetIP(ctx, false)
+// WaitForIP waits for a matching IP on a network adapter.
+func (vm *VirtualMachineDriver) WaitForIP(ctx context.Context, ipNet *net.IPNet, adapterIndex *int) (string, error) {
+	adapters, err := vm.NetworkAdapters(ctx)
+	if err != nil {
+		return "", err
+	}
+	if len(adapters) == 0 {
+		return "", fmt.Errorf("no network adapters found")
+	}
+
+	if adapterIndex != nil {
+		if *adapterIndex >= len(adapters) {
+			return "", AdapterIndexOutOfRangeError(*adapterIndex, len(adapters), "network adapters")
+		}
+		adapters = []NetworkAdapter{adapters[*adapterIndex]}
+	}
+
+	return vm.waitForMatchingNetIP(ctx, ipNet, adapters)
+}
+
+// AdapterIndexOutOfRangeError reports that ip_wait_adapter_index is not valid
+// for count adapters, named by noun (for example "network adapters").
+func AdapterIndexOutOfRangeError(index, count int, noun string) error {
+	if count <= 0 {
+		return fmt.Errorf("ip_wait_adapter_index is %d, but no %s are defined", index, noun)
+	}
+	return fmt.Errorf("ip_wait_adapter_index is %d; valid indexes are 0 to %d (%d %s)", index, count-1, count, noun)
+}
+
+// NetworkAdapter is a virtual network adapter, ordered the same way as
+// ip_wait_adapter_index (device key / network_adapters order).
+type NetworkAdapter struct {
+	Name string
+	MAC  string
+	Key  int32
+}
+
+func (vm *VirtualMachineDriver) waitForMatchingNetIP(ctx context.Context, ipNet *net.IPNet, adapters []NetworkAdapter) (string, error) {
+	p := property.DefaultCollector(vm.vm.Client())
+	var ip string
+	err := property.Wait(ctx, p, vm.vm.Reference(), []string{"guest.net"}, func(pc []types.PropertyChange) bool {
+		nics := guestNicsFromPropertyChange(pc)
+		if candidate := selectIPByNetworkAdapters(adapters, nics, ipNet); candidate != "" {
+			ip = candidate
+			return true
+		}
+		return false
+	})
 	if err != nil {
 		return "", err
 	}
 
-	for _, ips := range netIP {
-		for _, ip := range ips {
-			parseIP := net.ParseIP(ip)
-			if ipNet != nil && !ipNet.Contains(parseIP) {
-				// IP address is not in the expected range.
+	return ip, nil
+}
+
+// NetworkAdapters returns the virtual machine's network adapters in
+// ip_wait_adapter_index order, waiting until each has a MAC address.
+func (vm *VirtualMachineDriver) NetworkAdapters(ctx context.Context) ([]NetworkAdapter, error) {
+	p := property.DefaultCollector(vm.vm.Client())
+	var adapters []NetworkAdapter
+
+	err := property.Wait(ctx, p, vm.vm.Reference(), []string{"config.hardware.device"}, func(pc []types.PropertyChange) bool {
+		found := false
+		for _, c := range pc {
+			if c.Op != types.PropertyChangeOpAssign {
 				continue
 			}
-			// Default to IPv4 if no IPNet is provided.
-			if ipNet == nil && parseIP.To4() == nil {
+
+			devices := object.VirtualDeviceList(c.Val.(types.ArrayOfVirtualDevice).VirtualDevice)
+			nics := networkAdaptersFromDevices(devices)
+			if len(nics) == 0 {
+				return false
+			}
+			for _, nic := range nics {
+				if nic.MAC == "" {
+					return false
+				}
+			}
+			adapters = nics
+			found = true
+		}
+		return found
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return adapters, nil
+}
+
+func networkAdaptersFromDevices(devices object.VirtualDeviceList) []NetworkAdapter {
+	var adapters []NetworkAdapter
+	for _, d := range devices {
+		nic, ok := d.(types.BaseVirtualEthernetCard)
+		if !ok {
+			continue
+		}
+		card := nic.GetVirtualEthernetCard()
+		adapters = append(adapters, NetworkAdapter{
+			Name: devices.Name(d),
+			MAC:  strings.ToLower(card.MacAddress),
+			Key:  card.Key,
+		})
+	}
+	// Device keys increase as NICs are added, which matches network_adapters
+	// order. Unit number can be assigned out of that order and must not be used
+	// as the index.
+	sort.Slice(adapters, func(i, j int) bool {
+		return adapters[i].Key < adapters[j].Key
+	})
+	return adapters
+}
+
+func guestNicsFromPropertyChange(pc []types.PropertyChange) []types.GuestNicInfo {
+	var nics []types.GuestNicInfo
+	for _, c := range pc {
+		if c.Op != types.PropertyChangeOpAssign {
+			continue
+		}
+		nics = append(nics, c.Val.(types.ArrayOfGuestNicInfo).GuestNicInfo...)
+	}
+	return nics
+}
+
+func selectIPByNetworkAdapters(adapters []NetworkAdapter, nics []types.GuestNicInfo, ipNet *net.IPNet) string {
+	ipsByMAC := make(map[string][]string, len(nics))
+	v4 := ipNetWantsIPv4(ipNet)
+	for _, nic := range nics {
+		mac := strings.ToLower(nic.MacAddress)
+		if mac == "" || nic.IpConfig == nil {
+			continue
+		}
+		for _, addr := range nic.IpConfig.IpAddress {
+			if v4 && net.ParseIP(addr.IpAddress).To4() == nil {
 				continue
 			}
-			return ip, nil
+			ipsByMAC[mac] = append(ipsByMAC[mac], addr.IpAddress)
 		}
 	}
 
-	// Unable to find an IP address.
-	return "", nil
+	for _, adapter := range adapters {
+		for _, ip := range ipsByMAC[adapter.MAC] {
+			if ipMatchesFilter(ip, ipNet) {
+				return ip
+			}
+		}
+	}
+	return ""
+}
+
+func ipMatchesFilter(ip string, ipNet *net.IPNet) bool {
+	parseIP := net.ParseIP(ip)
+	if parseIP == nil {
+		return false
+	}
+	if ipNet != nil && !ipNet.Contains(parseIP) {
+		return false
+	}
+	if ipNet == nil && parseIP.To4() == nil {
+		return false
+	}
+	return true
+}
+
+// ipNetWantsIPv4 reports whether the wait filter should ignore non-IPv4 addresses
+// while waiting. Nil and IPv4 CIDRs (including the default 0.0.0.0/0) wait for IPv4
+// so IPv6 link-local addresses do not complete the wait.
+func ipNetWantsIPv4(ipNet *net.IPNet) bool {
+	if ipNet == nil {
+		return true
+	}
+	return ipNet.IP.To4() != nil
 }
 
 // PowerOff stops the virtual machine and waits for the operation to complete.

--- a/builder/vsphere/driver/vm_clone_acc_test.go
+++ b/builder/vsphere/driver/vm_clone_acc_test.go
@@ -242,7 +242,7 @@ func startAndStopCheck(t *testing.T, vm VirtualMachine, config *CloneConfig) {
 	stopper := startVM(t, vm, config.Name)
 	defer stopper()
 
-	switch ip, err := vm.WaitForIP(context.Background(), nil); {
+	switch ip, err := vm.WaitForIP(context.Background(), nil, nil); {
 	case err != nil:
 		t.Errorf("Cannot obtain IP address from created vm '%v': %v", config.Name, err)
 	case net.ParseIP(ip) == nil:

--- a/builder/vsphere/driver/vm_ip_test.go
+++ b/builder/vsphere/driver/vm_ip_test.go
@@ -1,0 +1,156 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package driver
+
+import (
+	"net"
+	"testing"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func guestNic(mac, ip string) types.GuestNicInfo {
+	nic := types.GuestNicInfo{MacAddress: mac}
+	if ip != "" {
+		nic.IpConfig = &types.NetIpConfigInfo{
+			IpAddress: []types.NetIpConfigInfoIpAddress{{IpAddress: ip}},
+		}
+	}
+	return nic
+}
+
+func TestSelectIPByNetworkAdapters(t *testing.T) {
+	_, cidr, err := net.ParseCIDR("192.168.86.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	adapters := []NetworkAdapter{
+		{Name: "ethernet-0", MAC: "00:50:56:81:9a:a5", Key: 4000},
+		{Name: "ethernet-1", MAC: "00:50:56:81:01:d1", Key: 4001},
+		{Name: "ethernet-2", MAC: "00:50:56:81:3e:82", Key: 4002},
+		{Name: "ethernet-3", MAC: "00:50:56:81:71:a0", Key: 4003},
+	}
+	nics := []types.GuestNicInfo{
+		guestNic("00:50:56:81:9a:a5", "192.168.86.201"),
+		guestNic("00:50:56:81:01:d1", "192.168.86.202"),
+		guestNic("00:50:56:81:71:a0", "192.168.86.203"),
+		guestNic("00:50:56:81:3e:82", "192.168.86.204"),
+	}
+
+	if got := selectIPByNetworkAdapters(adapters, nics, cidr); got != "192.168.86.201" {
+		t.Fatalf("any adapter = %q, want 192.168.86.201", got)
+	}
+	if got := selectIPByNetworkAdapters(adapters[2:3], nics, cidr); got != "192.168.86.204" {
+		t.Fatalf("index 2 = %q, want 192.168.86.204 (MAC of ethernet-2)", got)
+	}
+	if got := selectIPByNetworkAdapters(adapters[2:3], nics[:2], cidr); got != "" {
+		t.Fatalf("index 2 before that NIC has an IP = %q, want empty", got)
+	}
+}
+
+func TestSelectIPByNetworkAdapters_skipsIPv6UntilMatch(t *testing.T) {
+	_, cidr, err := net.ParseCIDR("192.168.86.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapters := []NetworkAdapter{{Name: "ethernet-0", MAC: "00:50:56:81:9a:a5"}}
+	nics := []types.GuestNicInfo{
+		{
+			MacAddress: "00:50:56:81:9a:a5",
+			IpConfig: &types.NetIpConfigInfo{
+				IpAddress: []types.NetIpConfigInfoIpAddress{
+					{IpAddress: "fe80::1"},
+					{IpAddress: "192.168.86.201"},
+				},
+			},
+		},
+	}
+	if got := selectIPByNetworkAdapters(adapters, nics, cidr); got != "192.168.86.201" {
+		t.Fatalf("got %q, want 192.168.86.201", got)
+	}
+}
+
+func TestIpMatchesFilter(t *testing.T) {
+	_, cidr, _ := net.ParseCIDR("192.168.0.0/16")
+
+	if !ipMatchesFilter("192.168.1.1", cidr) {
+		t.Fatal("expected match in cidr")
+	}
+	if ipMatchesFilter("10.0.0.1", cidr) {
+		t.Fatal("expected no match outside cidr")
+	}
+	if !ipMatchesFilter("10.0.0.1", nil) {
+		t.Fatal("expected ipv4 match with nil ipNet")
+	}
+	if ipMatchesFilter("2001:db8::1", nil) {
+		t.Fatal("expected ipv6 skip with nil ipNet")
+	}
+}
+
+func TestIpNetWantsIPv4(t *testing.T) {
+	if !ipNetWantsIPv4(nil) {
+		t.Fatal("expected nil ipNet to wait for ipv4")
+	}
+
+	_, v4, err := net.ParseCIDR("0.0.0.0/0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ipNetWantsIPv4(v4) {
+		t.Fatal("expected default ipv4 cidr to wait for ipv4")
+	}
+
+	_, v6, err := net.ParseCIDR("::/0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ipNetWantsIPv4(v6) {
+		t.Fatal("expected ipv6 cidr to wait for ipv6")
+	}
+}
+
+func vmxnet3(key, unit int32, mac string) *types.VirtualVmxnet3 {
+	u := unit
+	return &types.VirtualVmxnet3{
+		VirtualVmxnet: types.VirtualVmxnet{
+			VirtualEthernetCard: types.VirtualEthernetCard{
+				VirtualDevice: types.VirtualDevice{
+					Key:        key,
+					UnitNumber: &u,
+				},
+				MacAddress: mac,
+			},
+		},
+	}
+}
+
+func TestNetworkAdaptersFromDevices_followsAddOrderNotUnit(t *testing.T) {
+	// Third-added NIC has a higher unit number than the fourth. Index 2 must
+	// still be the third network_adapters entry (key 4002), not unit order.
+	devices := object.VirtualDeviceList{
+		vmxnet3(4000, 7, "00:50:56:81:00:01"),
+		vmxnet3(4001, 8, "00:50:56:81:00:02"),
+		vmxnet3(4002, 10, "00:50:56:81:00:03"),
+		vmxnet3(4003, 9, "00:50:56:81:00:04"),
+	}
+
+	got := networkAdaptersFromDevices(devices)
+	if len(got) != 4 {
+		t.Fatalf("len = %d, want 4", len(got))
+	}
+	wantMAC := []string{
+		"00:50:56:81:00:01",
+		"00:50:56:81:00:02",
+		"00:50:56:81:00:03",
+		"00:50:56:81:00:04",
+	}
+	for i, mac := range wantMAC {
+		if got[i].MAC != mac {
+			t.Errorf("index %d mac = %s, want %s (key %d)", i, got[i].MAC, mac, got[i].Key)
+		}
+	}
+}

--- a/builder/vsphere/driver/vm_mock.go
+++ b/builder/vsphere/driver/vm_mock.go
@@ -181,7 +181,7 @@ func (vm *VirtualMachineMock) PowerOn() error {
 	return nil
 }
 
-func (vm *VirtualMachineMock) WaitForIP(ctx context.Context, ipNet *net.IPNet) (string, error) {
+func (vm *VirtualMachineMock) WaitForIP(ctx context.Context, ipNet *net.IPNet, adapterIndex *int) (string, error) {
 	return "", nil
 }
 

--- a/builder/vsphere/iso/config.go
+++ b/builder/vsphere/iso/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 	"github.com/vmware/packer-plugin-vsphere/builder/vsphere/common"
+	"github.com/vmware/packer-plugin-vsphere/builder/vsphere/driver"
 )
 
 type Config struct {
@@ -125,6 +126,9 @@ func (c *Config) Prepare(raws ...any) ([]string, error) {
 	errs = packersdk.MultiErrorAppend(errs, c.CDConfig.Prepare(&c.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs, c.BootConfig.Prepare(&c.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs, c.WaitIpConfig.Prepare()...)
+	if c.WaitAdapterIndex != nil && len(c.NICs) > 0 && *c.WaitAdapterIndex >= len(c.NICs) {
+		errs = packersdk.MultiErrorAppend(errs, driver.AdapterIndexOutOfRangeError(*c.WaitAdapterIndex, len(c.NICs), "network adapters"))
+	}
 	errs = packersdk.MultiErrorAppend(errs, c.Comm.Prepare(&c.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs, c.VAppConfig.PrepareSSH(c.Comm)...)
 

--- a/builder/vsphere/iso/config.hcl2spec.go
+++ b/builder/vsphere/iso/config.hcl2spec.go
@@ -99,6 +99,7 @@ type FlatConfig struct {
 	WaitTimeout                     *string                                     `mapstructure:"ip_wait_timeout" cty:"ip_wait_timeout" hcl:"ip_wait_timeout"`
 	SettleTimeout                   *string                                     `mapstructure:"ip_settle_timeout" cty:"ip_settle_timeout" hcl:"ip_settle_timeout"`
 	WaitAddress                     *string                                     `mapstructure:"ip_wait_address" cty:"ip_wait_address" hcl:"ip_wait_address"`
+	WaitAdapterIndex                *int                                        `mapstructure:"ip_wait_adapter_index" cty:"ip_wait_adapter_index" hcl:"ip_wait_adapter_index"`
 	DisableIpWait                   *bool                                       `mapstructure:"disable_ip_wait" cty:"disable_ip_wait" hcl:"disable_ip_wait"`
 	Type                            *string                                     `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
 	PauseBeforeConnect              *string                                     `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
@@ -267,6 +268,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ip_wait_timeout":                &hcldec.AttrSpec{Name: "ip_wait_timeout", Type: cty.String, Required: false},
 		"ip_settle_timeout":              &hcldec.AttrSpec{Name: "ip_settle_timeout", Type: cty.String, Required: false},
 		"ip_wait_address":                &hcldec.AttrSpec{Name: "ip_wait_address", Type: cty.String, Required: false},
+		"ip_wait_adapter_index":          &hcldec.AttrSpec{Name: "ip_wait_adapter_index", Type: cty.Number, Required: false},
 		"disable_ip_wait":                &hcldec.AttrSpec{Name: "disable_ip_wait", Type: cty.Bool, Required: false},
 		"communicator":                   &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
 		"pause_before_connecting":        &hcldec.AttrSpec{Name: "pause_before_connecting", Type: cty.String, Required: false},

--- a/builder/vsphere/iso/config_test.go
+++ b/builder/vsphere/iso/config_test.go
@@ -9,6 +9,26 @@ import (
 	"testing"
 )
 
+func TestISOConfig_AdapterIndexOutOfRange(t *testing.T) {
+	raw := minimalISOConfig()
+	raw["ip_wait_adapter_index"] = 18
+	raw["network_adapters"] = []any{
+		map[string]any{"network": "VM Network", "network_card": "vmxnet3"},
+		map[string]any{"network": "VM Network", "network_card": "vmxnet3"},
+		map[string]any{"network": "VM Network", "network_card": "vmxnet3"},
+		map[string]any{"network": "VM Network", "network_card": "vmxnet3"},
+	}
+	c := new(Config)
+	_, err := c.Prepare(raw)
+	if err == nil {
+		t.Fatal("expected ip_wait_adapter_index error")
+	}
+	want := "ip_wait_adapter_index is 18; valid indexes are 0 to 3 (4 network adapters)"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("got %q, want it to contain %q", err.Error(), want)
+	}
+}
+
 func TestISOConfig_DisableIpWaitRequiresHost(t *testing.T) {
 	raw := minimalISOConfig()
 	raw["disable_ip_wait"] = true

--- a/docs-partials/builder/vsphere/common/DiskConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/DiskConfig-not-required.mdx
@@ -6,8 +6,8 @@
 - `disk_eagerly_scrub` (bool) - Enable eager scrubbing for the disk.
   Defaults to `false`.
 
-- `disk_controller_index` (int) - The assigned disk controller for the disk.
-  Defaults to the first controller, `(0)`.
+- `disk_controller_index` (int) - The assigned disk controller for the disk at the zero-based index
+  (0, 1, 2, ...). Defaults to the first controller, `(0)`.
   Mutually exclusive with `disk_controller_unit`.
 
 - `disk_controller_unit` (string) - Explicit controller address for the disk when cloning from a `template`

--- a/docs-partials/builder/vsphere/common/WaitIpConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/WaitIpConfig-not-required.mdx
@@ -1,33 +1,40 @@
 <!-- Code generated from the comments of the WaitIpConfig struct in builder/vsphere/common/step_wait_for_ip.go; DO NOT EDIT MANUALLY -->
 
-- `ip_wait_timeout` (duration string | ex: "1h5m2s") - Amount of time to wait for VM's IP, similar to 'ssh_timeout'.
-  Defaults to `30m` (30 minutes). Refer to the Golang
+- `ip_wait_timeout` (duration string | ex: "1h5m2s") - The amount of time to wait for virtual machine's IP, similar to
+  `ssh_timeout`. Defaults to `30m` (30 minutes). Refer to the Golang
   [ParseDuration](https://golang.org/pkg/time/#ParseDuration)
-  documentation for full details.
+  documentation for more information.
 
-- `ip_settle_timeout` (duration string | ex: "1h5m2s") - Amount of time to wait for VM's IP to settle down, sometimes VM may
-  report incorrect IP initially, then it is recommended to set that
-  parameter to apx. 2 minutes. Examples `45s` and `10m`.
-  Defaults to `5s` (5 seconds). Refer to the Golang
-  [ParseDuration](https://golang.org/pkg/time/#ParseDuration)
-  documentation for full details.
+- `ip_settle_timeout` (duration string | ex: "1h5m2s") - The amount of time to wait for virtual machine's IP to settle down. For
+  example, `45s` and `10m`. Defaults to `5s` (5 seconds). Refer to the
+  Golang [ParseDuration](https://golang.org/pkg/time/#ParseDuration)
+  documentation for more information.
 
-- `ip_wait_address` (\*string) - Set this to a CIDR address to cause the service to wait for an address that is contained in
-  this network range. Defaults to `0.0.0.0/0` for any IPv4 address.
+- `ip_wait_address` (\*string) - The IP address range in CIDR notation to wait for. Defaults to
+  `0.0.0.0/0` for any IPv4 address.
   
-  -> **Note:** This only filters which guest-reported IP is accepted; it does not disable IP wait. Use `disable_ip_wait` to skip
-  waiting for a guest-reported IP entirely. When `disable_ip_wait` is true, this setting still applies to HTTP IP discovery.
+  -> **Note:** This only filters which guest-reported IP is accepted; it
+  does not disable IP wait. Use `disable_ip_wait` to skip waiting for a
+  guest-reported IP entirely. When `disable_ip_wait` is `true`, this
+  setting still applies to HTTP IP discovery.
   
   Examples include:
   * empty string ("") - remove all filters
-  * `0:0:0:0:0:0:0:0/0` - allow only ipv6 addresses
-  * `192.168.1.0/24` - only allow ipv4 addresses from 192.168.1.1 to 192.168.1.254
+  * `0:0:0:0:0:0:0:0/0` - allow only IPv6 addresses
+  * `192.168.1.0/24` - only allow IPv4 addresses from 192.168.1.1 to 192.168.1.254
 
-- `disable_ip_wait` (bool) - When true, skip waiting for a guest-reported IP from vCenter. The default wait relies on
-  VMware Tools or open-vm-tools guest information. Use when they cannot be installed during
-  guest operating system install. Defaults to `false`.
+- `ip_wait_adapter_index` (\*int) - When set, wait for an IP on a specific network adapter at this zero-based
+  index (0, 1, 2, ...). For `vsphere-iso`, the index follows
+  `network_adapters` order (the first block is `0`). For `vsphere-clone`,
+  the index follows the order the adapters were added on the source virtual
+  machine.
+
+- `disable_ip_wait` (bool) - When `true`, skip waiting for a guest-reported IP from vCenter. The
+  default wait relies on VMware Tools or open-vm-tools guest information.
+  Use when they cannot be installed during guest operating system install.
+  Defaults to `false`.
   
-  -> **Note:** You must set `ssh_host` or `winrm_host`; reachability timing uses `ssh_timeout`
-  or `winrm_timeout`, not `ip_wait_timeout`.
+  -> **Note:** You must set `ssh_host` or `winrm_host`; reachability timing
+  uses `ssh_timeout` or `winrm_timeout`, not `ip_wait_timeout`.
 
 <!-- End of code generated from the comments of the WaitIpConfig struct in builder/vsphere/common/step_wait_for_ip.go; -->


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

Add optional `ip_wait_adapter_index` on `vsphere-iso` and `vsphere-clone` for environments where multiple NICs may receive routable addresses.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [x] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been added or updated.
- [x] Tests have been completed.

Output:

```hcl
...
  network_adapters {
    network_card = var.network_card
    network      = var.network_names[0]
  }
  network_adapters {
    network_card = var.network_card
    network      = var.network_names[1]
  }
  network_adapters {
    network_card = var.network_card
    network      = var.network_names[2]
  }
  network_adapters {
    network_card = var.network_card
    network      = var.network_names[3]
  }

  ip_wait_adapter_index = var.ip_wait_adapter_index
...
```

```shell
43:38 [INFO] Waiting for IP, up to total timeout: 30m0s, settle timeout: 5s
2026/08/25 14:43:38 ui: ==> vsphere-iso.example: Waiting for IP on specified network adapter...
2026/08/25 14:43:38 packer-plugin-vsphere_v2.5.0-dev_x5.0_darwin_arm64 plugin: 2026/08/25 14:43:38 [INFO] Waiting for IP on specified network adapter at index 3 (MAC: 00:50:56:81:e6:da)
2026/08/25 14:44:28 packer-plugin-vsphere_v2.5.0-dev_x5.0_darwin_arm64 plugin: 2026/08/25 14:44:28 VM IP acquired: 192.168.86.201
2026/08/25 14:44:28 packer-plugin-vsphere_v2.5.0-dev_x5.0_darwin_arm64 plugin: 2026/08/25 14:44:28 VM IP is still the same: 192.168.86.201
2026/08/25 14:44:29 packer-plugin-vsphere_v2.5.0-dev_x5.0_darwin_arm64 plugin: 2026/08/25 14:44:29 VM IP is still the same: 192.168.86.201
2026/08/25 14:44:30 packer-plugin-vsphere_v2.5.0-dev_x5.0_darwin_arm64 plugin: 2026/08/25 14:44:30 VM IP is still the same: 192.168.86.201
2026/08/25 14:44:31 packer-plugin-vsphere_v2.5.0-dev_x5.0_darwin_arm64 plugin: 2026/08/25 14:44:31 VM IP is still the same: 192.168.86.201
2026/08/25 14:44:32 packer-plugin-vsphere_v2.5.0-dev_x5.0_darwin_arm64 plugin: 2026/08/25 14:44:32 VM IP is still the same: 192.168.86.201
2026/08/25 14:44:33 packer-plugin-vsphere_v2.5.0-dev_x5.0_darwin_arm64 plugin: 2026/08/25 14:44:33 VM IP is still the same: 192.168.86.201
2026/08/25 14:44:33 packer-plugin-vsphere_v2.5.0-dev_x5.0_darwin_arm64 plugin: 2026/08/25 14:44:33 VM IP seems stable enough: 192.168.86.201
2026/08/25 14:44:33 ui: ==> vsphere-iso.example: IP address: 192.168.86.201
2026/08/25 14:44:33 ui: ==> vsphere-iso.example: Using SSH communicator to connect: 192.168.86.201
```

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [x] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

Closes #133

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->