### PR TITLE
feat: add local ovf/ova source support

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -62,16 +62,16 @@ references, which are necessary for a build to succeed and can be found further 
 - `template` (string) - The name of the source virtual machine template to clone. Specify either
   `template` or `ovf_source`, but not both.
 
-- `ovf_source` (\*OvfSourceConfig) - Configuration for deploying from an OVF/OVA source accessible using
-  HTTP or HTTPS. Conflicts with `template`.
+- `ovf_source` (\*OvfSourceConfig) - Configuration for deploying from an OVF/OVA source. Specify either a
+  remote `url` or a local `path`. Conflicts with `template`.
   
-  HTTP
+  Local
   
   HCL Example:
   
   ```hcl
   ovf_source {
-    url = "http://packages.example.com/templates/example.ovf"
+    path = "./artifacts/example.ovf"
   }
   ```
   
@@ -79,17 +79,19 @@ references, which are necessary for a build to succeed and can be found further 
   
   ```json
   "ovf_source": {
-    "url": "http://packages.example.com/templates/example.ovf"
+    "path": "./artifacts/example.ovf"
   }
   ```
   
-  HTTPS
+  -> **Note:** The `path` must end in `.ovf` or `.ova`.
+  
+  Remote
   
   HCL Example:
   
   ```hcl
   ovf_source {
-    url = "https://packages.example.com/templates/example.ovf"
+    url = "https://packages.example.com/artifacts/example.ovf"
   }
   ```
   
@@ -97,17 +99,18 @@ references, which are necessary for a build to succeed and can be found further 
   
   ```json
   "ovf_source": {
-    "url": "https://packages.example.com/templates/example.ovf"
+    "url": "https://packages.example.com/artifacts/example.ovf"
   }
   ```
   
-  HTTPS and Basic Authentication
+  -> **Note:** Use `http://` or `https://`. The `url` must end in `.ovf`
+  or `.ova`.
   
   HCL Example:
   
   ```hcl
   ovf_source {
-    url             = "https://packages.example.com/artifacts/example.ovf"
+    url             = "https://packages.example.com/artifacts/example.ova"
     username        = "ovf_source_username"
     password        = "ovf_source_password"
     skip_tls_verify = false
@@ -118,7 +121,7 @@ references, which are necessary for a build to succeed and can be found further 
   
   ```json
   "ovf_source": {
-    "url": "https://packages.example.com/artifacts/example.ovf",
+    "url": "https://packages.example.com/artifacts/example.ova",
     "username": "ovf_source_username",
     "password": "ovf_source_password",
     "skip_tls_verify": false
@@ -127,6 +130,9 @@ references, which are necessary for a build to succeed and can be found further 
   
   -> **Note:** For credentials, use variables marked `sensitive = true` for
   `username` and `password`.
+  
+  -> **Note:** When using a multi-file OVF, keep the descriptor and its disk
+  files in the same directory on the local and remote sources.
 
 - `disk_size` (int64) - The size of the primary disk in MiB. Conflicts with `linked_clone`.
   
@@ -180,15 +186,19 @@ references, which are necessary for a build to succeed and can be found further 
 <!-- Code generated from the comments of the OvfSourceConfig struct in builder/vsphere/clone/step_clone.go; DO NOT EDIT MANUALLY -->
 
 - `url` (string) - The URL of the remote OVF/OVA file. Supports HTTP and HTTPS protocols.
+  Conflicts with `path`.
+
+- `path` (string) - The path to a local OVF/OVA file on the host filesystem.
+  Conflicts with `url`.
 
 - `username` (string) - The username for basic authentication when accessing the remote OVF/OVA file.
-  Must be used together with `password`.
+  Must be used together with `password`. Only applicable when `url` is set.
 
 - `password` (string) - The password for basic authentication when accessing the remote OVF/OVA file.
-  Must be used together with `username`.
+  Must be used together with `username`. Only applicable when `url` is set.
 
 - `skip_tls_verify` (bool) - Do not validate the certificate when accessing HTTPS URLs.
-  Defaults to `false`.
+  Defaults to `false`. Only applicable when `url` is set.
   
   -> **Note:** This option is beneficial in scenarios where the certificate
   is self-signed or does not meet standard validation criteria.
@@ -217,10 +227,11 @@ When cloning from a `template`, the resulting virtual machine contains the
 source template's disks plus any newly configured disks and controllers.
 `storage {}`, `disk_controller_type`, and `disk_size` apply in this mode.
 
-When deploying from `ovf_source`, the plugin downloads the OVF/OVA package
-on the Packer host and imports it into vSphere using the OVF Manager and an
-NFC lease upload. Virtual disks, how many, how large, and how they are
-provisioned (for example, thin or thick) are provided by the OVF/OVA descriptor.
+When deploying from `ovf_source`, the plugin reads the OVF/OVA package on
+the Packer host (from an HTTP(S) URL or a local filesystem `path`) and
+imports it into vSphere using the OVF Manager and an NFC lease upload.
+Virtual disks, how many, how large, and how they are provisioned (for
+example, thin or thick) are provided by the OVF/OVA descriptor.
 When the descriptor offers multiple deployment sizes, use `vapp.deployment_option`
 to select one. For more information, refer to the [vApp Options Configuration](#vapp-options-configuration)
 section.

--- a/builder/vsphere/clone/builder.go
+++ b/builder/vsphere/clone/builder.go
@@ -223,7 +223,11 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		"metadata":       state.Get("metadata"),
 	}
 	if b.config.OvfSource != nil {
-		stateData["source_ovf_url"] = driver.SanitizeOvfURL(b.config.OvfSource.URL)
+		if b.config.OvfSource.Path != "" {
+			stateData["source_ovf_path"] = b.config.OvfSource.Path
+		} else {
+			stateData["source_ovf_url"] = driver.SanitizeOvfURL(b.config.OvfSource.URL)
+		}
 	} else {
 		stateData["source_template"] = b.config.Template
 	}

--- a/builder/vsphere/clone/config.hcl2spec.go
+++ b/builder/vsphere/clone/config.hcl2spec.go
@@ -321,6 +321,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatOvfSourceConfig struct {
 	URL           *string `mapstructure:"url" cty:"url" hcl:"url"`
+	Path          *string `mapstructure:"path" cty:"path" hcl:"path"`
 	Username      *string `mapstructure:"username" cty:"username" hcl:"username"`
 	Password      *string `mapstructure:"password" cty:"password" hcl:"password"`
 	SkipTlsVerify *bool   `mapstructure:"skip_tls_verify" cty:"skip_tls_verify" hcl:"skip_tls_verify"`
@@ -339,6 +340,7 @@ func (*OvfSourceConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcld
 func (*FlatOvfSourceConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"url":             &hcldec.AttrSpec{Name: "url", Type: cty.String, Required: false},
+		"path":            &hcldec.AttrSpec{Name: "path", Type: cty.String, Required: false},
 		"username":        &hcldec.AttrSpec{Name: "username", Type: cty.String, Required: false},
 		"password":        &hcldec.AttrSpec{Name: "password", Type: cty.String, Required: false},
 		"skip_tls_verify": &hcldec.AttrSpec{Name: "skip_tls_verify", Type: cty.Bool, Required: false},

--- a/builder/vsphere/clone/config_test.go
+++ b/builder/vsphere/clone/config_test.go
@@ -200,7 +200,7 @@ func TestCloneConfig_OvfSourceValidation(t *testing.T) {
 				},
 			},
 			expectError:    true,
-			expectedErrMsg: "'url' is required when using 'ovf_source'",
+			expectedErrMsg: "either 'url' or 'path' is required when using 'ovf_source'",
 		},
 		{
 			name: "Invalid: ovf_source URL missing",
@@ -218,7 +218,7 @@ func TestCloneConfig_OvfSourceValidation(t *testing.T) {
 				},
 			},
 			expectError:    true,
-			expectedErrMsg: "'url' is required when using 'ovf_source'",
+			expectedErrMsg: "either 'url' or 'path' is required when using 'ovf_source'",
 		},
 		{
 			name: "Invalid: ovf_source URL with unsupported protocol",
@@ -235,7 +235,7 @@ func TestCloneConfig_OvfSourceValidation(t *testing.T) {
 				},
 			},
 			expectError:    true,
-			expectedErrMsg: "'ovf_source' URL must use HTTP or HTTPS protocol",
+			expectedErrMsg: "'ovf_source' url must use HTTP or HTTPS protocol",
 		},
 		{
 			name: "Invalid: ovf_source URL with invalid format",
@@ -252,7 +252,24 @@ func TestCloneConfig_OvfSourceValidation(t *testing.T) {
 				},
 			},
 			expectError:    true,
-			expectedErrMsg: "invalid 'ovf_source' URL format",
+			expectedErrMsg: "invalid 'ovf_source' url format",
+		},
+		{
+			name: "Invalid: ovf_source URL with unsupported file extension",
+			config: map[string]interface{}{
+				"vcenter_server": "vcenter.example.com",
+				"username":       "administrator@vsphere.local",
+				"password":       "VMw@re1!",
+				"vm_name":        "vm-01",
+				"host":           "esxi-01.example.com",
+				"ssh_username":   "root",
+				"ssh_password":   "VMw@re1!",
+				"ovf_source": map[string]interface{}{
+					"url": "https://packages.example.com/artifacts/example.ovx",
+				},
+			},
+			expectError:    true,
+			expectedErrMsg: "'ovf_source' url must point to an OVF (.ovf) or OVA (.ova) file",
 		},
 		{
 			name: "Invalid: ovf_source username without password",

--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -12,7 +12,9 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
@@ -25,15 +27,19 @@ import (
 
 type OvfSourceConfig struct {
 	// The URL of the remote OVF/OVA file. Supports HTTP and HTTPS protocols.
+	// Conflicts with `path`.
 	URL string `mapstructure:"url"`
+	// The path to a local OVF/OVA file on the host filesystem.
+	// Conflicts with `url`.
+	Path string `mapstructure:"path"`
 	// The username for basic authentication when accessing the remote OVF/OVA file.
-	// Must be used together with `password`.
+	// Must be used together with `password`. Only applicable when `url` is set.
 	Username string `mapstructure:"username"`
 	// The password for basic authentication when accessing the remote OVF/OVA file.
-	// Must be used together with `username`.
+	// Must be used together with `username`. Only applicable when `url` is set.
 	Password string `mapstructure:"password"`
 	// Do not validate the certificate when accessing HTTPS URLs.
-	// Defaults to `false`.
+	// Defaults to `false`. Only applicable when `url` is set.
 	//
 	// -> **Note:** This option is beneficial in scenarios where the certificate
 	// is self-signed or does not meet standard validation criteria.
@@ -44,16 +50,16 @@ type CloneConfig struct {
 	// The name of the source virtual machine template to clone. Specify either
 	// `template` or `ovf_source`, but not both.
 	Template string `mapstructure:"template"`
-	// Configuration for deploying from an OVF/OVA source accessible using
-	// HTTP or HTTPS. Conflicts with `template`.
+	// Configuration for deploying from an OVF/OVA source. Specify either a
+	// remote `url` or a local `path`. Conflicts with `template`.
 	//
-	// HTTP
+	// Local
 	//
 	// HCL Example:
 	//
 	// ```hcl
 	// ovf_source {
-	//   url = "http://packages.example.com/templates/example.ovf"
+	//   path = "./artifacts/example.ovf"
 	// }
 	// ```
 	//
@@ -61,17 +67,19 @@ type CloneConfig struct {
 	//
 	// ```json
 	// "ovf_source": {
-	//   "url": "http://packages.example.com/templates/example.ovf"
+	//   "path": "./artifacts/example.ovf"
 	// }
 	// ```
 	//
-	// HTTPS
+	// -> **Note:** The `path` must end in `.ovf` or `.ova`.
+	//
+	// Remote
 	//
 	// HCL Example:
 	//
 	// ```hcl
 	// ovf_source {
-	//   url = "https://packages.example.com/templates/example.ovf"
+	//   url = "https://packages.example.com/artifacts/example.ovf"
 	// }
 	// ```
 	//
@@ -79,17 +87,18 @@ type CloneConfig struct {
 	//
 	// ```json
 	// "ovf_source": {
-	//   "url": "https://packages.example.com/templates/example.ovf"
+	//   "url": "https://packages.example.com/artifacts/example.ovf"
 	// }
 	// ```
 	//
-	// HTTPS and Basic Authentication
+	// -> **Note:** Use `http://` or `https://`. The `url` must end in `.ovf`
+	// or `.ova`.
 	//
 	// HCL Example:
 	//
 	// ```hcl
 	// ovf_source {
-	//   url             = "https://packages.example.com/artifacts/example.ovf"
+	//   url             = "https://packages.example.com/artifacts/example.ova"
 	//   username        = "ovf_source_username"
 	//   password        = "ovf_source_password"
 	//   skip_tls_verify = false
@@ -100,7 +109,7 @@ type CloneConfig struct {
 	//
 	// ```json
 	// "ovf_source": {
-	//   "url": "https://packages.example.com/artifacts/example.ovf",
+	//   "url": "https://packages.example.com/artifacts/example.ova",
 	//   "username": "ovf_source_username",
 	//   "password": "ovf_source_password",
 	//   "skip_tls_verify": false
@@ -109,6 +118,9 @@ type CloneConfig struct {
 	//
 	// -> **Note:** For credentials, use variables marked `sensitive = true` for
 	// `username` and `password`.
+	//
+	// -> **Note:** When using a multi-file OVF, keep the descriptor and its disk
+	// files in the same directory on the local and remote sources.
 	OvfSource *OvfSourceConfig `mapstructure:"ovf_source"`
 	// The size of the primary disk in MiB. Conflicts with `linked_clone`.
 	//
@@ -194,14 +206,54 @@ func (c *CloneConfig) Prepare() []error {
 func (c *CloneConfig) prepareOvfSource() []error {
 	var errs []error
 
-	if c.OvfSource.URL == "" {
-		errs = append(errs, fmt.Errorf("'url' is required when using 'ovf_source'"))
-	} else {
+	hasURL := c.OvfSource.URL != ""
+	hasPath := c.OvfSource.Path != ""
+
+	if hasURL && hasPath {
+		errs = append(errs, fmt.Errorf("'ovf_source' cannot specify both 'url' and 'path'"))
+	}
+	if !hasURL && !hasPath {
+		errs = append(errs, fmt.Errorf("either 'url' or 'path' is required when using 'ovf_source'"))
+	}
+
+	if hasURL {
 		parsedURL, err := url.Parse(c.OvfSource.URL)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("invalid 'ovf_source' URL format: %s", err))
+			errs = append(errs, fmt.Errorf("invalid 'ovf_source' url format: %s", err))
 		} else if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
-			errs = append(errs, fmt.Errorf("'ovf_source' URL must use HTTP or HTTPS protocol"))
+			errs = append(errs, fmt.Errorf("'ovf_source' url must use HTTP or HTTPS protocol"))
+		} else {
+			lower := strings.ToLower(parsedURL.Path)
+			if !strings.HasSuffix(lower, ".ovf") && !strings.HasSuffix(lower, ".ova") {
+				errs = append(errs, fmt.Errorf("'ovf_source' url must point to an OVF (.ovf) or OVA (.ova) file"))
+			}
+		}
+	}
+
+	if hasPath {
+		cleaned := filepath.Clean(c.OvfSource.Path)
+		c.OvfSource.Path = cleaned
+		lower := strings.ToLower(cleaned)
+		if !strings.HasSuffix(lower, ".ovf") && !strings.HasSuffix(lower, ".ova") {
+			errs = append(errs, fmt.Errorf("'ovf_source' path must point to an OVF (.ovf) or OVA (.ova) file"))
+		} else {
+			info, err := os.Stat(cleaned)
+			if err != nil {
+				if os.IsNotExist(err) {
+					errs = append(errs, fmt.Errorf("'ovf_source' path '%s' does not exist", cleaned))
+				} else {
+					errs = append(errs, fmt.Errorf("unable to access 'ovf_source' path '%s': %s", cleaned, err))
+				}
+			} else if info.IsDir() {
+				errs = append(errs, fmt.Errorf("'ovf_source' path '%s' is a directory; specify an OVF or OVA file", cleaned))
+			}
+		}
+
+		if c.OvfSource.Username != "" || c.OvfSource.Password != "" {
+			errs = append(errs, fmt.Errorf("'username' and 'password' are only applicable when 'url' is set"))
+		}
+		if c.OvfSource.SkipTlsVerify {
+			errs = append(errs, fmt.Errorf("'skip_tls_verify' is only applicable when 'url' is set"))
 		}
 	}
 
@@ -382,8 +434,11 @@ func (s *StepCloneVM) deployFromOvf(ctx context.Context, state multistep.StateBa
 		}
 	}
 
+	sourceLabel := driver.SanitizeOvfSource(s.Config.OvfSource.URL, s.Config.OvfSource.Path)
+
 	ovfConfig := &driver.OvfDeployConfig{
 		URL:              s.Config.OvfSource.URL,
+		Path:             s.Config.OvfSource.Path,
 		Authentication:   auth,
 		Name:             s.Location.VMName,
 		Folder:           s.Location.Folder,
@@ -402,13 +457,13 @@ func (s *StepCloneVM) deployFromOvf(ctx context.Context, state multistep.StateBa
 
 	// Validate OVF deployment parameters with enhanced error handling
 	if err := s.validateOvfConfiguration(ctx, d, ovfConfig); err != nil {
-		state.Put("error", s.wrapStepError("OVF configuration validation failed", err, s.Config.OvfSource.URL))
+		state.Put("error", s.wrapStepError("OVF configuration validation failed", err, sourceLabel))
 		return multistep.ActionHalt
 	}
 
 	vm, err := d.DeployOvf(ctx, ovfConfig, ui)
 	if err != nil {
-		state.Put("error", s.wrapStepError("OVF deployment failed", err, s.Config.OvfSource.URL))
+		state.Put("error", s.wrapStepError("OVF deployment failed", err, sourceLabel))
 		return multistep.ActionHalt
 	}
 
@@ -450,7 +505,9 @@ func (s *StepCloneVM) validateOvfDeploymentOption(ctx context.Context, d driver.
 	if locale == "" {
 		locale = "US"
 	}
-	options, err := d.GetOvfOptions(ctx, config.URL, config.Authentication, locale, config.SkipTlsVerify)
+	optionsConfig := *config
+	optionsConfig.Locale = locale
+	options, err := d.GetOvfOptions(ctx, &optionsConfig)
 	if err != nil {
 		return fmt.Errorf("error retrieving OVF deployment options: %s", err)
 	}
@@ -513,10 +570,9 @@ func (s *StepCloneVM) validateOvfVAppProperties(_ context.Context, _ driver.Driv
 }
 
 // wrapStepError wraps errors with context and sanitizes sensitive information for step operations.
-func (s *StepCloneVM) wrapStepError(context string, err error, url string) error {
-	sanitizedURL := driver.SanitizeOvfURL(url)
+func (s *StepCloneVM) wrapStepError(context string, err error, source string) error {
 	sanitizedErr := driver.SanitizeOvfErrorMessage(err.Error())
-	return fmt.Errorf("%s for OVF source '%s': %s", context, sanitizedURL, sanitizedErr)
+	return fmt.Errorf("%s for OVF source '%s': %s", context, source, sanitizedErr)
 }
 
 // Cleanup performs step cleanup.

--- a/builder/vsphere/clone/step_clone_test.go
+++ b/builder/vsphere/clone/step_clone_test.go
@@ -8,7 +8,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -159,7 +161,7 @@ func TestCreateConfig_Prepare(t *testing.T) {
 				OvfSource: &OvfSourceConfig{},
 			},
 			fail:           true,
-			expectedErrMsg: "'url' is required when using 'ovf_source'",
+			expectedErrMsg: "either 'url' or 'path' is required when using 'ovf_source'",
 		},
 		{
 			name: "Validate ovf_source URL protocol",
@@ -169,7 +171,17 @@ func TestCreateConfig_Prepare(t *testing.T) {
 				},
 			},
 			fail:           true,
-			expectedErrMsg: "'ovf_source' URL must use HTTP or HTTPS protocol",
+			expectedErrMsg: "'ovf_source' url must use HTTP or HTTPS protocol",
+		},
+		{
+			name: "Validate ovf_source URL extension",
+			config: &CloneConfig{
+				OvfSource: &OvfSourceConfig{
+					URL: "https://packages.example.com/artifacts/example.ovx",
+				},
+			},
+			fail:           true,
+			expectedErrMsg: "'ovf_source' url must point to an OVF (.ovf) or OVA (.ova) file",
 		},
 		{
 			name: "Validate ovf_source username requires password",
@@ -253,6 +265,69 @@ func TestCreateConfig_Prepare(t *testing.T) {
 			fail:           true,
 			expectedErrMsg: "'disk_controller_type' cannot be used with 'ovf_source'",
 		},
+		{
+			name: "Valid ovf_source path config",
+			config: &CloneConfig{
+				OvfSource: &OvfSourceConfig{
+					Path: createTempOvfFile(t),
+				},
+			},
+			fail: false,
+		},
+		{
+			name: "Validate ovf_source cannot set both url and path",
+			config: &CloneConfig{
+				OvfSource: &OvfSourceConfig{
+					URL:  "https://packages.example.com/artifacts/example.ovf",
+					Path: createTempOvfFile(t),
+				},
+			},
+			fail:           true,
+			expectedErrMsg: "'ovf_source' cannot specify both 'url' and 'path'",
+		},
+		{
+			name: "Validate ovf_source path must exist",
+			config: &CloneConfig{
+				OvfSource: &OvfSourceConfig{
+					Path: filepath.Join(t.TempDir(), "missing.ovf"),
+				},
+			},
+			fail:           true,
+			expectedErrMsg: "does not exist",
+		},
+		{
+			name: "Validate ovf_source path extension",
+			config: &CloneConfig{
+				OvfSource: &OvfSourceConfig{
+					Path: filepath.Join(t.TempDir(), "example.vmdk"),
+				},
+			},
+			fail:           true,
+			expectedErrMsg: "'ovf_source' path must point to an OVF (.ovf) or OVA (.ova) file",
+		},
+		{
+			name: "Validate auth not allowed with path",
+			config: &CloneConfig{
+				OvfSource: &OvfSourceConfig{
+					Path:     createTempOvfFile(t),
+					Username: "user",
+					Password: "pass",
+				},
+			},
+			fail:           true,
+			expectedErrMsg: "'username' and 'password' are only applicable when 'url' is set",
+		},
+		{
+			name: "Validate skip_tls_verify not allowed with path",
+			config: &CloneConfig{
+				OvfSource: &OvfSourceConfig{
+					Path:          createTempOvfFile(t),
+					SkipTlsVerify: true,
+				},
+			},
+			fail:           true,
+			expectedErrMsg: "'skip_tls_verify' is only applicable when 'url' is set",
+		},
 	}
 
 	for _, c := range tc {
@@ -262,8 +337,8 @@ func TestCreateConfig_Prepare(t *testing.T) {
 				if len(errs) == 0 {
 					t.Fatal("unexpected success: expected failure")
 				}
-				if errs[0].Error() != c.expectedErrMsg {
-					t.Fatalf("unexpected error: expected '%s', but returned '%s'", c.expectedErrMsg, errs[0])
+				if c.expectedErrMsg != "" && !strings.Contains(errs[0].Error(), c.expectedErrMsg) {
+					t.Fatalf("unexpected error: expected to contain '%s', but returned '%s'", c.expectedErrMsg, errs[0])
 				}
 			} else {
 				if len(errs) != 0 {
@@ -272,6 +347,15 @@ func TestCreateConfig_Prepare(t *testing.T) {
 			}
 		})
 	}
+}
+
+func createTempOvfFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "example.ovf")
+	if err := os.WriteFile(path, []byte("<Envelope/>"), 0o644); err != nil {
+		t.Fatalf("write temp ovf: %s", err)
+	}
+	return path
 }
 
 func TestStepCreateVM_Run(t *testing.T) {
@@ -500,6 +584,42 @@ func TestStepCloneVM_OvfDeploymentUsesResolvedDatastore(t *testing.T) {
 	}
 	if driverMock.DeployOvfConfig.Datastore != "drs-selected-datastore" {
 		t.Errorf("expected datastore 'drs-selected-datastore', got '%s'", driverMock.DeployOvfConfig.Datastore)
+	}
+}
+
+func TestStepCloneVM_OvfLocalPathDeploy(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+	state.Put("ui", &packersdk.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	})
+	driverMock := driver.NewDriverMock()
+	driverMock.DeployOvfVM = new(driver.VirtualMachineMock)
+	state.Put("driver", driverMock)
+
+	localPath := createTempOvfFile(t)
+	step := &StepCloneVM{
+		Config: &CloneConfig{
+			OvfSource: &OvfSourceConfig{
+				Path: localPath,
+			},
+		},
+		Location: basicLocationConfig(),
+		Force:    true,
+	}
+
+	action := step.Run(context.Background(), state)
+	if action != multistep.ActionContinue {
+		t.Fatalf("expected ActionContinue, got %v; error: %v", action, state.Get("error"))
+	}
+	if !driverMock.DeployOvfCalled {
+		t.Fatal("expected DeployOvf to be called")
+	}
+	if driverMock.DeployOvfConfig.Path != localPath {
+		t.Errorf("expected Path %q, got %q", localPath, driverMock.DeployOvfConfig.Path)
+	}
+	if driverMock.DeployOvfConfig.URL != "" {
+		t.Errorf("expected empty URL for local path deploy, got %q", driverMock.DeployOvfConfig.URL)
 	}
 }
 

--- a/builder/vsphere/common/artifact.go
+++ b/builder/vsphere/common/artifact.go
@@ -102,6 +102,12 @@ func (a *Artifact) stateHCPPackerRegistryMetadata() interface{} {
 		labels["source_ovf_url"] = ovfURL
 	}
 
+	ovfPath, ok := a.StateData["source_ovf_path"].(string)
+	if ok && ovfPath != "" {
+		sourceID = ovfPath
+		labels["source_ovf_path"] = ovfPath
+	}
+
 	img, _ := registryimage.FromArtifact(a,
 		registryimage.WithID(a.Name),
 		registryimage.WithRegion(a.Datacenter.Name()),

--- a/builder/vsphere/common/artifact_test.go
+++ b/builder/vsphere/common/artifact_test.go
@@ -104,3 +104,32 @@ func TestArtifactHCPPackerRegistrySourceRemoteURL(t *testing.T) {
 		t.Fatalf("unexpected source_ovf_url label: got %v", metadata.Labels["source_ovf_url"])
 	}
 }
+
+func TestArtifactState_OvfLocalPathMetadata(t *testing.T) {
+	sim, err := NewVCenterSimulator()
+	if err != nil {
+		t.Fatalf("should not fail: %s", err)
+	}
+	defer sim.Close()
+
+	vm, _ := sim.ChooseSimulatorPreCreatedVM()
+
+	artifact := &Artifact{
+		Name:       "test-vm",
+		Datacenter: vm.Datacenter(),
+		StateData: map[string]interface{}{
+			"source_ovf_path": "./artifacts/example.ova",
+		},
+	}
+
+	metadata, ok := artifact.State(registryimage.ArtifactStateURI).(*registryimage.Image)
+	if !ok {
+		t.Fatalf("unexpected result: expected '*registryimage.Image', but returned '%T'", artifact.State(registryimage.ArtifactStateURI))
+	}
+	if metadata.SourceImageID != "./artifacts/example.ova" {
+		t.Fatalf("unexpected SourceImageID: got %q", metadata.SourceImageID)
+	}
+	if metadata.Labels["source_ovf_path"] != "./artifacts/example.ova" {
+		t.Fatalf("unexpected source_ovf_path label: got %v", metadata.Labels["source_ovf_path"])
+	}
+}

--- a/builder/vsphere/common/storage_config.go
+++ b/builder/vsphere/common/storage_config.go
@@ -114,10 +114,11 @@ type DiskConfig struct {
 // source template's disks plus any newly configured disks and controllers.
 // `storage {}`, `disk_controller_type`, and `disk_size` apply in this mode.
 //
-// When deploying from `ovf_source`, the plugin downloads the OVF/OVA package
-// on the Packer host and imports it into vSphere using the OVF Manager and an
-// NFC lease upload. Virtual disks, how many, how large, and how they are
-// provisioned (for example, thin or thick) are provided by the OVF/OVA descriptor.
+// When deploying from `ovf_source`, the plugin reads the OVF/OVA package on
+// the Packer host (from an HTTP(S) URL or a local filesystem `path`) and
+// imports it into vSphere using the OVF Manager and an NFC lease upload.
+// Virtual disks, how many, how large, and how they are provisioned (for
+// example, thin or thick) are provided by the OVF/OVA descriptor.
 // When the descriptor offers multiple deployment sizes, use `vapp.deployment_option`
 // to select one. For more information, refer to the [vApp Options Configuration](#vapp-options-configuration)
 // section.

--- a/builder/vsphere/driver/driver.go
+++ b/builder/vsphere/driver/driver.go
@@ -57,7 +57,7 @@ type Driver interface {
 	GetRestClient() *rest.Client
 	DeleteContentLibraryItem(itemID string) error
 	DeployOvf(ctx context.Context, config *OvfDeployConfig, ui packersdk.Ui) (VirtualMachine, error)
-	GetOvfOptions(ctx context.Context, url string, auth *OvfAuthConfig, locale string, skipTlsVerify bool) ([]types.OvfOptionInfo, error)
+	GetOvfOptions(ctx context.Context, config *OvfDeployConfig) ([]types.OvfOptionInfo, error)
 	Cleanup() (error, error)
 }
 
@@ -101,9 +101,10 @@ type OvfAuthConfig struct {
 }
 
 // OvfDeployConfig contains configuration for deploying virtual machines from
-// remote OVF/OVA sources.
+// OVF/OVA sources. Exactly one of URL or Path must be set.
 type OvfDeployConfig struct {
-	URL              string
+	URL              string // HTTP(S) URL of a remote OVF/OVA file.
+	Path             string // Local filesystem path to an OVF/OVA file.
 	Authentication   *OvfAuthConfig
 	Name             string
 	Folder           string
@@ -118,6 +119,17 @@ type OvfDeployConfig struct {
 	DeploymentOption string // OVF deployment option such as "small", "medium", or "large".
 	Locale           string // Locale for OVF deployment messages and descriptions (defaults to "US" if empty).
 	SkipTlsVerify    bool   // Skip TLS certificate verification for HTTPS URLs (for testing environments only).
+}
+
+// ovfSourceLabel returns a sanitized label for the OVF source for errors and logs.
+func (c *OvfDeployConfig) ovfSourceLabel() string {
+	if c == nil {
+		return ""
+	}
+	if c.Path != "" {
+		return c.Path
+	}
+	return SanitizeOvfURL(c.URL)
 }
 
 func NewDriver(config *ConnectConfig) (Driver, error) {
@@ -178,58 +190,59 @@ func (d *VCenterDriver) GetRestClient() *rest.Client {
 	return d.RestClient.client
 }
 
-// DeployOvf deploys a virtual machine from a remote OVF/OVA source.
+// DeployOvf deploys a virtual machine from an OVF/OVA source.
 //
-// The plugin downloads the OVF descriptor and archive files over HTTP(S) on
-// the Packer host, passes the descriptor XML to vSphere's OVF Manager, and
-// uploads disk files through an NFC lease. vSphere does not fetch the remote
-// URL directly.
+// The plugin reads the OVF descriptor and archive files on the Packer host
+// (from an HTTP(S) URL or a local filesystem path), passes the descriptor XML
+// to vSphere's OVF Manager, and uploads disk files through an NFC lease.
+// vSphere does not fetch the source directly.
 func (d *VCenterDriver) DeployOvf(ctx context.Context, config *OvfDeployConfig, ui packersdk.Ui) (VirtualMachine, error) {
+	label := config.ovfSourceLabel()
 	if err := d.validateOvfDeploymentConfig(config); err != nil {
-		return nil, d.wrapOvfError("configuration validation failed", err, config.URL)
+		return nil, d.wrapOvfError("configuration validation failed", err, label)
 	}
 
 	ovfWrapper, err := d.createOvfManagerWrapper(config.Authentication, config.SkipTlsVerify)
 	if err != nil {
-		return nil, d.wrapOvfError("failed to initialize OVF manager", err, config.URL)
+		return nil, d.wrapOvfError("failed to initialize OVF manager", err, label)
 	}
 
-	// Validate remote OVF accessibility before proceeding with vSphere resource lookup.
-	parseResult, err := d.validateRemoteOvfAccessibility(ctx, config, ovfWrapper)
+	// Validate OVF accessibility before proceeding with vSphere resource lookup.
+	parseResult, err := d.validateOvfAccessibility(ctx, config, ovfWrapper)
 	if err != nil {
-		return nil, d.wrapOvfError("remote OVF/OVA source validation failed", err, config.URL)
+		return nil, d.wrapOvfError("OVF/OVA source validation failed", err, label)
 	}
 
 	folder, err := d.FindFolder(config.Folder)
 	if err != nil {
-		return nil, d.wrapOvfError("failed to find target folder", err, config.URL)
+		return nil, d.wrapOvfError("failed to find target folder", err, label)
 	}
 
 	resourcePool, err := d.FindResourcePool(config.Cluster, config.Host, config.ResourcePool)
 	if err != nil {
-		return nil, d.wrapOvfError("failed to find resource pool", err, config.URL)
+		return nil, d.wrapOvfError("failed to find resource pool", err, label)
 	}
 
 	datastore, err := d.FindDatastore(config.Datastore, config.Host)
 	if err != nil {
-		return nil, d.wrapOvfError("failed to find datastore", err, config.URL)
+		return nil, d.wrapOvfError("failed to find datastore", err, label)
 	}
 
 	importParams, err := d.createOvfImportParams(config, parseResult)
 	if err != nil {
-		return nil, d.wrapOvfError("failed to create import parameters", err, config.URL)
+		return nil, d.wrapOvfError("failed to create import parameters", err, label)
 	}
 
-	log.Printf("[INFO] Creating OVF import specification from remote source...")
+	log.Printf("[INFO] Creating OVF import specification from OVF/OVA source...")
 
-	importSpecResult, err := ovfWrapper.CreateImportSpecFromURL(ctx, config.URL, resourcePool.pool, datastore.Reference(), importParams)
+	importSpecResult, err := ovfWrapper.CreateImportSpec(ctx, config, resourcePool.pool, datastore.Reference(), importParams)
 	if err != nil {
-		return nil, d.wrapOvfError("failed to create import specification", err, config.URL)
+		return nil, d.wrapOvfError("failed to create import specification", err, label)
 	}
 
 	// Handle OVF validation errors with detailed messages.
 	if len(importSpecResult.Error) > 0 {
-		return nil, d.handleOvfValidationErrors(importSpecResult.Error, config.URL)
+		return nil, d.handleOvfValidationErrors(importSpecResult.Error, label)
 	}
 
 	// Handle OVF warnings, if present.
@@ -242,13 +255,13 @@ func (d *VCenterDriver) DeployOvf(ctx context.Context, config *OvfDeployConfig, 
 	// Start the vApp import: vSphere returns an NFC lease through which disk files are uploaded.
 	lease, err := resourcePool.pool.ImportVApp(ctx, importSpecResult.ImportSpec, folder.folder, nil)
 	if err != nil {
-		return nil, d.wrapOvfError("failed to start vApp import", err, config.URL)
+		return nil, d.wrapOvfError("failed to start vApp import", err, label)
 	}
 
-	// Upload disk files from the remote source and complete the import.
+	// Upload disk files from the OVF/OVA source and complete the import.
 	info, err := d.uploadAndCompleteOvfImport(ctx, lease, config, importSpecResult.FileItem)
 	if err != nil {
-		return nil, d.wrapOvfError("OVF import operation failed", err, config.URL)
+		return nil, d.wrapOvfError("OVF import operation failed", err, label)
 	}
 
 	// Validate that we received a valid virtual machine reference.
@@ -260,13 +273,13 @@ func (d *VCenterDriver) DeployOvf(ctx context.Context, config *OvfDeployConfig, 
 	vmRef := info.Entity
 	vm := d.NewVM(&vmRef)
 	if err := d.applyOvfPostImportConfig(vm, config); err != nil {
-		return nil, d.wrapOvfError("failed to apply post-import virtual machine configuration", err, config.URL)
+		return nil, d.wrapOvfError("failed to apply post-import virtual machine configuration", err, label)
 	}
 	return vm, nil
 }
 
 // uploadAndCompleteOvfImport waits for the NFC lease to be ready, uploads all
-// disk files from the remote source through the Packer host, and signals
+// disk files from the OVF/OVA source through the Packer host, and signals
 // vSphere to complete the import.
 func (d *VCenterDriver) uploadAndCompleteOvfImport(ctx context.Context, lease *nfc.Lease, config *OvfDeployConfig, fileItems []types.OvfFileItem) (*nfc.LeaseInfo, error) {
 	// Wait for the lease to initialise and return the list of upload targets.
@@ -280,7 +293,7 @@ func (d *VCenterDriver) uploadAndCompleteOvfImport(ctx context.Context, lease *n
 	updater := lease.StartUpdater(ctx, info)
 	defer updater.Done()
 
-	archive, err := newRemoteOvfArchive(config.URL, config.Authentication, config.SkipTlsVerify)
+	archive, err := newOvfArchive(config)
 	if err != nil {
 		_ = lease.Abort(ctx, nil)
 		return nil, fmt.Errorf("failed to initialise OVF archive for upload: %s", err)
@@ -303,12 +316,12 @@ func (d *VCenterDriver) uploadAndCompleteOvfImport(ctx context.Context, lease *n
 	return info, nil
 }
 
-// uploadOvfFile opens the named file from the remote archive and uploads it to
+// uploadOvfFile opens the named file from the OVF/OVA archive and uploads it to
 // vSphere via the NFC lease.
-func (d *VCenterDriver) uploadOvfFile(ctx context.Context, lease *nfc.Lease, archive *remoteOvfArchive, item nfc.FileItem) error {
+func (d *VCenterDriver) uploadOvfFile(ctx context.Context, lease *nfc.Lease, archive ovfArchive, item nfc.FileItem) error {
 	rc, size, err := archive.Open(item.Path)
 	if err != nil {
-		return fmt.Errorf("failed to open '%s' from remote source: %s", item.Path, err)
+		return fmt.Errorf("failed to open '%s' from OVF/OVA source: %s", item.Path, err)
 	}
 	defer rc.Close()
 
@@ -355,33 +368,38 @@ func (d *VCenterDriver) applyOvfPostImportConfig(vm VirtualMachine, config *OvfD
 	return vm.Reconfigure(configSpec)
 }
 
-// GetOvfOptions retrieves OVF deployment options from a remote OVF/OVA source.
-// The descriptor is downloaded over HTTP(S) on the Packer host before being
-// parsed via vSphere's OVF Manager.
-func (d *VCenterDriver) GetOvfOptions(ctx context.Context, url string, auth *OvfAuthConfig, locale string, skipTlsVerify bool) ([]types.OvfOptionInfo, error) {
-	if err := d.validateOvfURL(url); err != nil {
-		return nil, d.wrapOvfError("URL validation failed", err, url)
+// GetOvfOptions retrieves OVF deployment options from an OVF/OVA source.
+// The descriptor is read on the Packer host before being parsed via vSphere's
+// OVF Manager.
+func (d *VCenterDriver) GetOvfOptions(ctx context.Context, config *OvfDeployConfig) ([]types.OvfOptionInfo, error) {
+	if config == nil {
+		return nil, fmt.Errorf("OVF deployment configuration cannot be nil")
+	}
+	label := config.ovfSourceLabel()
+	if err := d.validateOvfSource(config); err != nil {
+		return nil, d.wrapOvfError("source validation failed", err, label)
 	}
 
-	ovfWrapper, err := d.createOvfManagerWrapper(auth, skipTlsVerify)
+	ovfWrapper, err := d.createOvfManagerWrapper(config.Authentication, config.SkipTlsVerify)
 	if err != nil {
-		return nil, d.wrapOvfError("failed to initialize OVF manager", err, url)
+		return nil, d.wrapOvfError("failed to initialize OVF manager", err, label)
 	}
 
+	locale := config.Locale
 	if locale == "" {
 		locale = "US"
 	}
 
 	parseParams := d.createOvfParseParams(locale)
 
-	parseResult, err := ovfWrapper.ParseDescriptorFromURL(ctx, url, parseParams)
+	parseResult, err := ovfWrapper.ParseDescriptor(ctx, config, parseParams)
 	if err != nil {
-		return nil, d.wrapOvfError("failed to parse OVF descriptor", err, url)
+		return nil, d.wrapOvfError("failed to parse OVF descriptor", err, label)
 	}
 
 	// Handle parse errors, if present.
 	if len(parseResult.Error) > 0 {
-		return nil, d.handleOvfValidationErrors(parseResult.Error, url)
+		return nil, d.handleOvfValidationErrors(parseResult.Error, label)
 	}
 
 	var optionInfos []types.OvfOptionInfo
@@ -460,6 +478,15 @@ func (d *VCenterDriver) validateOvfURL(urlStr string) error {
 	}
 }
 
+// isOvfFileExtension checks whether pathOrURL ends with .ovf or .ova.
+func (d *VCenterDriver) isOvfFileExtension(pathOrURL string) bool {
+	if pathOrURL == "" {
+		return false
+	}
+	lower := strings.ToLower(pathOrURL)
+	return strings.HasSuffix(lower, ".ovf") || strings.HasSuffix(lower, ".ova")
+}
+
 // isOvfFileURL checks if the URL points to an OVF or OVA file based on file
 // extension.
 func (d *VCenterDriver) isOvfFileURL(urlStr string) bool {
@@ -467,9 +494,54 @@ func (d *VCenterDriver) isOvfFileURL(urlStr string) bool {
 	if err != nil {
 		return false
 	}
+	return d.isOvfFileExtension(parsedURL.Path)
+}
 
-	path := parsedURL.Path
-	return strings.HasSuffix(strings.ToLower(path), ".ovf") || strings.HasSuffix(strings.ToLower(path), ".ova")
+// validateOvfSource validates that exactly one of URL or Path is set and that
+// source-specific options are consistent.
+func (d *VCenterDriver) validateOvfSource(config *OvfDeployConfig) error {
+	if config == nil {
+		return fmt.Errorf("OVF deployment configuration cannot be nil")
+	}
+
+	hasURL := config.URL != ""
+	hasPath := config.Path != ""
+	if hasURL && hasPath {
+		return fmt.Errorf("OVF source cannot specify both URL and Path")
+	}
+	if !hasURL && !hasPath {
+		return fmt.Errorf("OVF source requires either URL or Path")
+	}
+
+	if hasPath {
+		if !d.isOvfFileExtension(config.Path) {
+			return fmt.Errorf("local OVF/OVA path must point to an OVF (.ovf) or OVA (.ova) file")
+		}
+		if config.Authentication != nil && (config.Authentication.Username != "" || config.Authentication.Password != "") {
+			return fmt.Errorf("authentication is only applicable when using a remote OVF/OVA URL")
+		}
+		if config.SkipTlsVerify {
+			return fmt.Errorf("skip_tls_verify is only applicable when using a remote OVF/OVA URL")
+		}
+		return nil
+	}
+
+	if err := d.validateOvfURL(config.URL); err != nil {
+		return err
+	}
+	if !d.isOvfFileURL(config.URL) {
+		return fmt.Errorf("URL must point to an OVF (.ovf) or OVA (.ova) file")
+	}
+	if err := d.validateOvfAuthentication(config.Authentication); err != nil {
+		return err
+	}
+	if config.SkipTlsVerify {
+		parsedURL, _ := url.Parse(config.URL)
+		if parsedURL != nil && parsedURL.Scheme == "http" {
+			return fmt.Errorf("skip_tls_verify is only applicable for HTTPS URLs, but URL uses HTTP protocol")
+		}
+	}
+	return nil
 }
 
 // validateOvfDeploymentConfig validates the complete OVF deployment
@@ -479,35 +551,11 @@ func (d *VCenterDriver) validateOvfDeploymentConfig(config *OvfDeployConfig) err
 		return fmt.Errorf("OVF deployment configuration cannot be nil")
 	}
 
-	if config.URL == "" {
-		return fmt.Errorf("OVF/OVA URL is required")
-	}
-
 	if config.Name == "" {
 		return fmt.Errorf("virtual machine name is required")
 	}
 
-	if err := d.validateOvfURL(config.URL); err != nil {
-		return err
-	}
-
-	if err := d.validateOvfAuthentication(config.Authentication); err != nil {
-		return err
-	}
-
-	if !d.isOvfFileURL(config.URL) {
-		return fmt.Errorf("URL must point to an OVF (.ovf) or OVA (.ova) file")
-	}
-
-	// Validate TLS configuration.
-	if config.SkipTlsVerify {
-		parsedURL, _ := url.Parse(config.URL)
-		if parsedURL.Scheme == "http" {
-			return fmt.Errorf("skip_tls_verify is only applicable for HTTPS URLs, but URL uses HTTP protocol")
-		}
-	}
-
-	return nil
+	return d.validateOvfSource(config)
 }
 
 // createOvfImportParams creates import parameters with authentication and
@@ -571,58 +619,58 @@ func (d *VCenterDriver) createOvfParseParams(locale string) types.OvfParseDescri
 	}
 }
 
-// fetchOvfXML downloads and returns the OVF descriptor XML bytes from the
-// remote URL on the Packer host. For OVA archives the descriptor is extracted
-// from the TAR; for OVF URLs it is fetched directly.
-func (w *OvfManagerWrapper) fetchOvfXML(urlStr string) ([]byte, error) {
-	archive, err := newRemoteOvfArchive(urlStr, w.auth, w.insecureSkipTLSVerify)
+// fetchOvfXML reads and returns the OVF descriptor XML bytes on the Packer
+// host. For OVA archives the descriptor is extracted from the TAR; for OVF
+// sources it is read directly.
+func (w *OvfManagerWrapper) fetchOvfXML(config *OvfDeployConfig) ([]byte, error) {
+	archive, err := newOvfArchive(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize OVF archive: %s", err)
 	}
 
 	// OVA: glob inside the TAR for the first .ovf entry.
-	// OVF: open the descriptor URL directly (empty name).
+	// OVF: open the descriptor directly (empty name).
 	name := ""
-	if archive.isOva {
+	if isOvfSourceOVA(config) {
 		name = "*.ovf"
 	}
 
 	rc, _, err := archive.Open(name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read OVF descriptor from '%s': %s", SanitizeOvfURL(urlStr), err)
+		return nil, fmt.Errorf("failed to read OVF descriptor from '%s': %s", config.ovfSourceLabel(), err)
 	}
 	defer rc.Close()
 
 	return io.ReadAll(rc)
 }
 
-// CreateImportSpecFromURL downloads the OVF descriptor on the Packer host and
-// creates an import spec from the XML via vSphere's OVF Manager.
-func (w *OvfManagerWrapper) CreateImportSpecFromURL(ctx context.Context, urlStr string, rp *object.ResourcePool, ds types.ManagedObjectReference, params *types.OvfCreateImportSpecParams) (*types.OvfCreateImportSpecResult, error) {
-	xmlBytes, err := w.fetchOvfXML(urlStr)
+// CreateImportSpec reads the OVF descriptor on the Packer host and creates an
+// import spec from the XML via vSphere's OVF Manager.
+func (w *OvfManagerWrapper) CreateImportSpec(ctx context.Context, config *OvfDeployConfig, rp *object.ResourcePool, ds types.ManagedObjectReference, params *types.OvfCreateImportSpecParams) (*types.OvfCreateImportSpecResult, error) {
+	xmlBytes, err := w.fetchOvfXML(config)
 	if err != nil {
 		return nil, err
 	}
 
 	result, err := w.manager.CreateImportSpec(ctx, string(xmlBytes), rp, ds, params)
 	if err != nil {
-		return nil, w.categorizeOvfManagerError(err, urlStr)
+		return nil, w.categorizeOvfManagerError(err, config.ovfSourceLabel())
 	}
 
 	return result, nil
 }
 
-// ParseDescriptorFromURL downloads the OVF descriptor on the Packer host and
-// parses the XML via vSphere's OVF Manager.
-func (w *OvfManagerWrapper) ParseDescriptorFromURL(ctx context.Context, urlStr string, params types.OvfParseDescriptorParams) (*types.OvfParseDescriptorResult, error) {
-	xmlBytes, err := w.fetchOvfXML(urlStr)
+// ParseDescriptor reads the OVF descriptor on the Packer host and parses the
+// XML via vSphere's OVF Manager.
+func (w *OvfManagerWrapper) ParseDescriptor(ctx context.Context, config *OvfDeployConfig, params types.OvfParseDescriptorParams) (*types.OvfParseDescriptorResult, error) {
+	xmlBytes, err := w.fetchOvfXML(config)
 	if err != nil {
 		return nil, err
 	}
 
 	result, err := w.manager.ParseDescriptor(ctx, string(xmlBytes), params)
 	if err != nil {
-		return nil, w.categorizeOvfManagerError(err, urlStr)
+		return nil, w.categorizeOvfManagerError(err, config.ovfSourceLabel())
 	}
 
 	return result, nil
@@ -739,28 +787,31 @@ func (d *VCenterDriver) containsAny(s string, patterns []string) bool {
 }
 
 // wrapOvfError wraps errors with context and sanitizes sensitive information.
-func (d *VCenterDriver) wrapOvfError(context string, err error, url string) error {
-	sanitizedURL := SanitizeOvfURL(url)
+func (d *VCenterDriver) wrapOvfError(context string, err error, source string) error {
+	sanitizedSource := SanitizeOvfErrorMessage(source)
+	if strings.Contains(source, "://") {
+		sanitizedSource = SanitizeOvfURL(source)
+	}
 	sanitizedErr := SanitizeOvfErrorMessage(err.Error())
-	return fmt.Errorf("%s for OVF/OVA source '%s': %s", context, sanitizedURL, sanitizedErr)
+	return fmt.Errorf("%s for OVF/OVA source '%s': %s", context, sanitizedSource, sanitizedErr)
 }
 
-// validateRemoteOvfAccessibility downloads and parses the remote OVF
-// descriptor on the Packer host before deployment proceeds.
-func (d *VCenterDriver) validateRemoteOvfAccessibility(ctx context.Context, config *OvfDeployConfig, wrapper *OvfManagerWrapper) (*types.OvfParseDescriptorResult, error) {
+// validateOvfAccessibility reads and parses the OVF descriptor on the Packer
+// host before deployment proceeds.
+func (d *VCenterDriver) validateOvfAccessibility(ctx context.Context, config *OvfDeployConfig, wrapper *OvfManagerWrapper) (*types.OvfParseDescriptorResult, error) {
 	locale := config.Locale
 	if locale == "" {
 		locale = "US"
 	}
 
 	parseParams := d.createOvfParseParams(locale)
-	parseResult, err := wrapper.ParseDescriptorFromURL(ctx, config.URL, parseParams)
+	parseResult, err := wrapper.ParseDescriptor(ctx, config, parseParams)
 	if err != nil {
-		return nil, fmt.Errorf("failed to access or parse remote OVF descriptor: %s", err)
+		return nil, fmt.Errorf("failed to access or parse OVF descriptor: %s", err)
 	}
 
 	if len(parseResult.Error) > 0 {
-		return nil, d.handleOvfValidationErrors(parseResult.Error, config.URL)
+		return nil, d.handleOvfValidationErrors(parseResult.Error, config.ovfSourceLabel())
 	}
 
 	return parseResult, nil
@@ -768,11 +819,14 @@ func (d *VCenterDriver) validateRemoteOvfAccessibility(ctx context.Context, conf
 
 // handleOvfValidationErrors processes OVF validation errors and provides
 // detailed error messages.
-func (d *VCenterDriver) handleOvfValidationErrors(errors []types.LocalizedMethodFault, url string) error {
-	sanitizedURL := SanitizeOvfURL(url)
+func (d *VCenterDriver) handleOvfValidationErrors(errors []types.LocalizedMethodFault, source string) error {
+	sanitizedSource := source
+	if strings.Contains(source, "://") {
+		sanitizedSource = SanitizeOvfURL(source)
+	}
 
 	if len(errors) == 1 {
-		return fmt.Errorf("OVF validation failed for '%s': %s", sanitizedURL, errors[0].LocalizedMessage)
+		return fmt.Errorf("OVF validation failed for '%s': %s", sanitizedSource, errors[0].LocalizedMessage)
 	}
 
 	const maxErrors = 5
@@ -787,7 +841,7 @@ func (d *VCenterDriver) handleOvfValidationErrors(errors []types.LocalizedMethod
 	}
 
 	return fmt.Errorf("OVF validation failed for '%s' with %d errors:\n%s",
-		sanitizedURL, len(errors), strings.Join(errorMessages, "\n"))
+		sanitizedSource, len(errors), strings.Join(errorMessages, "\n"))
 }
 
 // min returns the minimum of two integers.

--- a/builder/vsphere/driver/driver_mock.go
+++ b/builder/vsphere/driver/driver_mock.go
@@ -42,14 +42,16 @@ type DriverMock struct {
 	DeployOvfError      error
 	DeployOvfVM         VirtualMachine
 
-	GetOvfOptionsCalled        bool
+	GetOvfOptionsCalled     bool
+	GetOvfOptionsConfig     *OvfDeployConfig
+	GetOvfOptionsShouldFail bool
+	GetOvfOptionsError      error
+	GetOvfOptionsResult     []types.OvfOptionInfo
+	// Deprecated fields retained for existing tests that assert URL/auth/locale/tls.
 	GetOvfOptionsURL           string
 	GetOvfOptionsAuth          *OvfAuthConfig
 	GetOvfOptionsLocale        string
 	GetOvfOptionsSkipTlsVerify bool
-	GetOvfOptionsShouldFail    bool
-	GetOvfOptionsError         error
-	GetOvfOptionsResult        []types.OvfOptionInfo
 }
 
 // NewDriverMock creates a new instance of DriverMock for testing.
@@ -173,12 +175,15 @@ func (d *DriverMock) DeployOvf(ctx context.Context, config *OvfDeployConfig, ui 
 }
 
 // GetOvfOptions mocks OVF options retrieval functionality for testing.
-func (d *DriverMock) GetOvfOptions(ctx context.Context, url string, auth *OvfAuthConfig, locale string, skipTlsVerify bool) ([]types.OvfOptionInfo, error) {
+func (d *DriverMock) GetOvfOptions(ctx context.Context, config *OvfDeployConfig) ([]types.OvfOptionInfo, error) {
 	d.GetOvfOptionsCalled = true
-	d.GetOvfOptionsURL = url
-	d.GetOvfOptionsAuth = auth
-	d.GetOvfOptionsLocale = locale
-	d.GetOvfOptionsSkipTlsVerify = skipTlsVerify
+	d.GetOvfOptionsConfig = config
+	if config != nil {
+		d.GetOvfOptionsURL = config.URL
+		d.GetOvfOptionsAuth = config.Authentication
+		d.GetOvfOptionsLocale = config.Locale
+		d.GetOvfOptionsSkipTlsVerify = config.SkipTlsVerify
+	}
 
 	if d.GetOvfOptionsShouldFail {
 		if d.GetOvfOptionsError != nil {

--- a/builder/vsphere/driver/driver_test.go
+++ b/builder/vsphere/driver/driver_test.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -398,194 +397,6 @@ func TestOvfManagerWrapper_IsOvfFileURL(t *testing.T) {
 	}
 }
 
-// TestRemoteOvfArchive_AuthURL tests that newRemoteOvfArchive embeds
-// authentication credentials into the raw URL correctly.
-func TestRemoteOvfArchive_AuthURL(t *testing.T) {
-	tests := []struct {
-		name        string
-		originalURL string
-		auth        *OvfAuthConfig
-		expectedURL string
-		expectError bool
-	}{
-		{
-			name:        "No authentication",
-			originalURL: "https://packages.example.com/artifacts/example.ovf",
-			auth:        nil,
-			expectedURL: "https://packages.example.com/artifacts/example.ovf",
-			expectError: false,
-		},
-		{
-			name:        "Empty authentication",
-			originalURL: "https://packages.example.com/artifacts/example.ovf",
-			auth:        &OvfAuthConfig{},
-			expectedURL: "https://packages.example.com/artifacts/example.ovf",
-			expectError: false,
-		},
-		{
-			name:        "Basic authentication",
-			originalURL: "https://packages.example.com/artifacts/example.ovf",
-			auth: &OvfAuthConfig{
-				Username: "testuser",
-				Password: "testpass",
-			},
-			expectedURL: "https://testuser:testpass@packages.example.com/artifacts/example.ovf",
-			expectError: false,
-		},
-		{
-			name:        "Invalid URL",
-			originalURL: "://invalid-url",
-			auth: &OvfAuthConfig{
-				Username: "testuser",
-				Password: "testpass",
-			},
-			expectedURL: "",
-			expectError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			archive, err := newRemoteOvfArchive(tt.originalURL, tt.auth, false)
-
-			if tt.expectError {
-				if err == nil {
-					t.Errorf("expected error but got none")
-				}
-				return
-			}
-			if err != nil {
-				t.Errorf("unexpected error: %s", err)
-				return
-			}
-			if archive.rawURL != tt.expectedURL {
-				t.Errorf("expected rawURL '%s', got '%s'", tt.expectedURL, archive.rawURL)
-			}
-		})
-	}
-}
-
-func TestHttpOvfFetchError(t *testing.T) {
-	const fileURL = "https://user:secret@packages.example.com/artifacts/example.ovf"
-	const sanitized = "https://packages.example.com/artifacts/example.ovf"
-
-	tests := []struct {
-		name           string
-		statusCode     int
-		wantContains   []string
-		wantNotContain string
-	}{
-		{
-			name:         "unauthorized",
-			statusCode:   http.StatusUnauthorized,
-			wantContains: []string{"authentication failed", "(HTTP 401)", sanitized},
-		},
-		{
-			name:         "forbidden",
-			statusCode:   http.StatusForbidden,
-			wantContains: []string{"access denied", "(HTTP 403)", sanitized},
-		},
-		{
-			name:         "not found",
-			statusCode:   http.StatusNotFound,
-			wantContains: []string{"OVF/OVA file not found", "(HTTP 404)", sanitized},
-		},
-		{
-			name:         "gone",
-			statusCode:   http.StatusGone,
-			wantContains: []string{"no longer available", "(HTTP 410)", sanitized},
-		},
-		{
-			name:         "rate limited",
-			statusCode:   http.StatusTooManyRequests,
-			wantContains: []string{"rate-limited", "(HTTP 429)", sanitized},
-		},
-		{
-			name:         "server error",
-			statusCode:   http.StatusInternalServerError,
-			wantContains: []string{"remote server error", "(HTTP 500)", sanitized},
-		},
-		{
-			name:         "unexpected client error",
-			statusCode:   http.StatusBadRequest,
-			wantContains: []string{"unexpected HTTP 400", sanitized},
-		},
-		{
-			name:           "strips credentials from URL",
-			statusCode:     http.StatusNotFound,
-			wantContains:   []string{sanitized},
-			wantNotContain: "secret",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := httpOvfFetchError(tt.statusCode, fileURL)
-			if err == nil {
-				t.Fatal("expected error, got nil")
-			}
-			msg := err.Error()
-			for _, want := range tt.wantContains {
-				if !strings.Contains(msg, want) {
-					t.Errorf("error %q missing %q", msg, want)
-				}
-			}
-			if tt.wantNotContain != "" && strings.Contains(msg, tt.wantNotContain) {
-				t.Errorf("error %q must not contain %q", msg, tt.wantNotContain)
-			}
-		})
-	}
-}
-
-func TestRemoteOvfArchive_OpenHTTPStatusErrors(t *testing.T) {
-	tests := []struct {
-		name         string
-		statusCode   int
-		wantContains string
-	}{
-		{
-			name:         "unauthorized",
-			statusCode:   http.StatusUnauthorized,
-			wantContains: "authentication failed",
-		},
-		{
-			name:         "not found",
-			statusCode:   http.StatusNotFound,
-			wantContains: "OVF/OVA file not found",
-		},
-		{
-			name:         "forbidden",
-			statusCode:   http.StatusForbidden,
-			wantContains: "access denied",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(tt.statusCode)
-			}))
-			defer server.Close()
-
-			archive, err := newRemoteOvfArchive(server.URL+"/artifacts/example.ovf", nil, false)
-			if err != nil {
-				t.Fatalf("unexpected error creating archive: %s", err)
-			}
-
-			_, _, err = archive.Open("")
-			if err == nil {
-				t.Fatal("expected error, got nil")
-			}
-			if !strings.Contains(err.Error(), tt.wantContains) {
-				t.Errorf("error %q missing %q", err.Error(), tt.wantContains)
-			}
-			if !strings.Contains(err.Error(), fmt.Sprintf("(HTTP %d)", tt.statusCode)) {
-				t.Errorf("error %q missing HTTP status %d", err.Error(), tt.statusCode)
-			}
-		})
-	}
-}
-
 // TestDeployOvf_ValidConfiguration tests successful OVF deployment with valid
 // configuration.
 func TestDeployOvf_ValidConfiguration(t *testing.T) {
@@ -663,7 +474,7 @@ func TestDeployOvf_InvalidConfiguration(t *testing.T) {
 				Datastore:    "LocalDS_0",
 			},
 			expectError: true,
-			errorMsg:    "OVF/OVA URL is required",
+			errorMsg:    "OVF source requires either URL or Path",
 		},
 		{
 			name: "Missing VM name",
@@ -728,6 +539,60 @@ func TestDeployOvf_InvalidConfiguration(t *testing.T) {
 			},
 			expectError: true,
 			errorMsg:    "skip_tls_verify is only applicable for HTTPS URLs, but URL uses HTTP protocol",
+		},
+		{
+			name: "Both URL and Path specified",
+			config: &OvfDeployConfig{
+				URL:          "https://packages.example.com/artifacts/example.ovf",
+				Path:         "./artifacts/example.ovf",
+				Name:         "test-vm",
+				Folder:       "vm",
+				ResourcePool: "Resources",
+				Datastore:    "LocalDS_0",
+			},
+			expectError: true,
+			errorMsg:    "cannot specify both URL and Path",
+		},
+		{
+			name: "Local path with authentication",
+			config: &OvfDeployConfig{
+				Path: "./artifacts/example.ovf",
+				Name: "test-vm",
+				Authentication: &OvfAuthConfig{
+					Username: "testuser",
+					Password: "testpass",
+				},
+				Folder:       "vm",
+				ResourcePool: "Resources",
+				Datastore:    "LocalDS_0",
+			},
+			expectError: true,
+			errorMsg:    "authentication is only applicable when using a remote OVF/OVA URL",
+		},
+		{
+			name: "Local path with SkipTlsVerify",
+			config: &OvfDeployConfig{
+				Path:          "./artifacts/example.ova",
+				Name:          "test-vm",
+				Folder:        "vm",
+				ResourcePool:  "Resources",
+				Datastore:     "LocalDS_0",
+				SkipTlsVerify: true,
+			},
+			expectError: true,
+			errorMsg:    "skip_tls_verify is only applicable when using a remote OVF/OVA URL",
+		},
+		{
+			name: "Local path without OVF/OVA extension",
+			config: &OvfDeployConfig{
+				Path:         "./artifacts/example.vmdk",
+				Name:         "test-vm",
+				Folder:       "vm",
+				ResourcePool: "Resources",
+				Datastore:    "LocalDS_0",
+			},
+			expectError: true,
+			errorMsg:    "local OVF/OVA path must point to an OVF (.ovf) or OVA (.ova) file",
 		},
 	}
 
@@ -987,7 +852,7 @@ func TestGetOvfOptions_ValidConfiguration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := driver.GetOvfOptions(ctx, tt.url, tt.auth, tt.locale, false)
+			_, err := driver.GetOvfOptions(ctx, &OvfDeployConfig{URL: tt.url, Authentication: tt.auth, Locale: tt.locale})
 
 			// Expected panic due to simulator limitations for OVF parsing,
 			// but the error should not be a configuration validation error.
@@ -1076,7 +941,7 @@ func TestGetOvfOptions_InvalidConfiguration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := driver.GetOvfOptions(ctx, tt.url, tt.auth, tt.locale, false)
+			_, err := driver.GetOvfOptions(ctx, &OvfDeployConfig{URL: tt.url, Authentication: tt.auth, Locale: tt.locale})
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("expected error but got none")
@@ -1332,116 +1197,6 @@ func TestOvfManagerWrapper_VAppPropertiesHandling(t *testing.T) {
 	}
 }
 
-// TestOvfManagerWrapper_NetworkMappingHandling tests network mapping handling
-// in OVF deployment.
-func TestOvfManagerWrapper_NetworkMappingHandling(t *testing.T) {
-	sim, err := NewVCenterSimulator()
-	if err != nil {
-		t.Fatalf("unexpected error creating simulator: %s", err)
-	}
-	defer sim.Close()
-
-	driver := sim.driver
-
-	tests := []struct {
-		name         string
-		ovfNetworks  []types.OvfNetworkInfo
-		network      string
-		expectError  bool
-		errorMsg     string
-		expectMapped int
-		expectNames  []string
-	}{
-		{
-			name:         "No OVF networks",
-			ovfNetworks:  nil,
-			network:      "VM Network",
-			expectMapped: 0,
-		},
-		{
-			name: "Single OVF network mapped",
-			ovfNetworks: []types.OvfNetworkInfo{
-				{Name: "Management Network"},
-			},
-			network:      "VM Network",
-			expectMapped: 1,
-			expectNames:  []string{"Management Network"},
-		},
-		{
-			name: "Multiple OVF networks mapped to same vSphere network",
-			ovfNetworks: []types.OvfNetworkInfo{
-				{Name: "Management Network"},
-				{Name: "VM Network"},
-			},
-			network:      "VM Network",
-			expectMapped: 2,
-			expectNames:  []string{"Management Network", "VM Network"},
-		},
-		{
-			name: "OVF networks require configured network",
-			ovfNetworks: []types.OvfNetworkInfo{
-				{Name: "Guest Network"},
-			},
-			network:     "",
-			expectError: true,
-			errorMsg:    "OVF requires network mapping",
-		},
-		{
-			name: "Invalid vSphere network",
-			ovfNetworks: []types.OvfNetworkInfo{
-				{Name: "Guest Network"},
-			},
-			network:     "nonexistent-network",
-			expectError: true,
-			errorMsg:    "error finding network",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			parseResult := &types.OvfParseDescriptorResult{
-				Network: tt.ovfNetworks,
-			}
-			config := &OvfDeployConfig{
-				URL:          "https://packages.example.com/artifacts/example.ovf",
-				Name:         "test-vm",
-				Folder:       "vm",
-				ResourcePool: "Resources",
-				Datastore:    "LocalDS_0",
-				Network:      tt.network,
-			}
-
-			importParams, err := driver.createOvfImportParams(config, parseResult)
-			if tt.expectError {
-				if err == nil {
-					t.Fatal("expected error but got none")
-				}
-				if tt.errorMsg != "" && !strings.Contains(err.Error(), tt.errorMsg) {
-					t.Fatalf("expected error containing %q, got %q", tt.errorMsg, err.Error())
-				}
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("unexpected error: %s", err)
-			}
-			if importParams == nil {
-				t.Fatal("expected import params to be created but got nil")
-			}
-
-			if len(importParams.NetworkMapping) != tt.expectMapped {
-				t.Fatalf("expected %d network mappings, got %d", tt.expectMapped, len(importParams.NetworkMapping))
-			}
-
-			for i, expectedName := range tt.expectNames {
-				if importParams.NetworkMapping[i].Name != expectedName {
-					t.Errorf("mapping[%d].Name = %q, want %q", i, importParams.NetworkMapping[i].Name, expectedName)
-				}
-			}
-		})
-	}
-}
-
 // TestDriverMock_DeployOvf tests the mock driver's OVF deployment functionality.
 func TestDriverMock_DeployOvf(t *testing.T) {
 	ctx := context.Background()
@@ -1522,7 +1277,7 @@ func TestDriverMock_GetOvfOptions(t *testing.T) {
 
 	// Test successful options retrieval.
 	t.Run("Successful options retrieval", func(t *testing.T) {
-		options, err := mock.GetOvfOptions(ctx, url, auth, locale, false)
+		options, err := mock.GetOvfOptions(ctx, &OvfDeployConfig{URL: url, Authentication: auth, Locale: locale})
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		}
@@ -1559,7 +1314,7 @@ func TestDriverMock_GetOvfOptions(t *testing.T) {
 		mock.GetOvfOptionsShouldFail = true
 		mock.GetOvfOptionsError = fmt.Errorf("custom options error")
 
-		options, err := mock.GetOvfOptions(ctx, url, auth, locale, false)
+		options, err := mock.GetOvfOptions(ctx, &OvfDeployConfig{URL: url, Authentication: auth, Locale: locale})
 		if err == nil {
 			t.Errorf("expected error but got none")
 		}
@@ -1576,7 +1331,7 @@ func TestDriverMock_GetOvfOptions(t *testing.T) {
 		mock.GetOvfOptionsShouldFail = true
 		mock.GetOvfOptionsError = nil // Use default error.
 
-		options, err := mock.GetOvfOptions(ctx, url, auth, locale, false)
+		options, err := mock.GetOvfOptions(ctx, &OvfDeployConfig{URL: url, Authentication: auth, Locale: locale})
 		if err == nil {
 			t.Errorf("expected error but got none")
 		}
@@ -1602,7 +1357,7 @@ func TestDriverMock_GetOvfOptions(t *testing.T) {
 		}
 		mock.GetOvfOptionsResult = customOptions
 
-		options, err := mock.GetOvfOptions(ctx, url, auth, locale, false)
+		options, err := mock.GetOvfOptions(ctx, &OvfDeployConfig{URL: url, Authentication: auth, Locale: locale})
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		}
@@ -1833,7 +1588,7 @@ func TestOvfManagerWrapper_ConcurrentAccess(t *testing.T) {
 		for i := 0; i < numGoroutines; i++ {
 			go func(id int) {
 				url := fmt.Sprintf("https://packages%d.example.com/artifacts/example.ovf", id)
-				_, err := driver.GetOvfOptions(ctx, url, nil, "US", false)
+				_, err := driver.GetOvfOptions(ctx, &OvfDeployConfig{URL: url, Locale: "US"})
 				results <- err
 			}(i)
 		}
@@ -1881,79 +1636,6 @@ func TestOvfManagerWrapper_ConcurrentAccess(t *testing.T) {
 			}
 		}
 	})
-}
-
-// TestSanitizeOvfErrorMessage tests the sanitization of sensitive information in error messages.
-func TestSanitizeOvfErrorMessage(t *testing.T) {
-	testCases := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "URL with credentials",
-			input:    "error accessing https://user:password@packages.example.com/artifacts/example.ovf",
-			expected: "error accessing https://packages.example.com/artifacts/example.ovf",
-		},
-		{
-			name:     "Password in error message",
-			input:    "authentication failed: password=testpass",
-			expected: "authentication failed: [credentials removed]",
-		},
-		{
-			name:     "Multiple credential patterns",
-			input:    "failed with password=secret and token=abc123",
-			expected: "failed with [credentials removed] and [credentials removed]",
-		},
-		{
-			name:     "No credentials to sanitize",
-			input:    "network timeout error",
-			expected: "network timeout error",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := SanitizeOvfErrorMessage(tc.input)
-			if result != tc.expected {
-				t.Errorf("expected %q, got %q", tc.expected, result)
-			}
-		})
-	}
-}
-
-// TestSanitizeOvfURL tests the sanitization of credentials from URLs.
-func TestSanitizeOvfURL(t *testing.T) {
-	testCases := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "URL with username and password",
-			input:    "https://testuser:testpass@packages.example.com/artifacts/example.ovf",
-			expected: "https://packages.example.com/artifacts/example.ovf",
-		},
-		{
-			name:     "URL without credentials",
-			input:    "https://packages.example.com/artifacts/example.ovf",
-			expected: "https://packages.example.com/artifacts/example.ovf",
-		},
-		{
-			name:     "Relative URL without credentials",
-			input:    "not-a-url",
-			expected: "not-a-url",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := SanitizeOvfURL(tc.input)
-			if result != tc.expected {
-				t.Errorf("expected %q, got %q", tc.expected, result)
-			}
-		})
-	}
 }
 
 // TestCategorizeOvfImportError tests the categorization of OVF import errors.

--- a/builder/vsphere/driver/ovf_archive.go
+++ b/builder/vsphere/driver/ovf_archive.go
@@ -13,8 +13,50 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 )
+
+// ovfArchive opens named files from an OVF/OVA source on the Packer host.
+type ovfArchive interface {
+	Open(name string) (io.ReadCloser, int64, error)
+}
+
+// newOvfArchive selects a remote or local archive implementation based on
+// OvfDeployConfig. Exactly one of URL or Path must be set.
+func newOvfArchive(config *OvfDeployConfig) (ovfArchive, error) {
+	if config == nil {
+		return nil, fmt.Errorf("OVF deployment configuration cannot be nil")
+	}
+	if config.URL != "" && config.Path != "" {
+		return nil, fmt.Errorf("OVF source cannot specify both URL and Path")
+	}
+	if config.URL != "" {
+		return newRemoteOvfArchive(config.URL, config.Authentication, config.SkipTlsVerify)
+	}
+	if config.Path != "" {
+		return newLocalOvfArchive(config.Path)
+	}
+	return nil, fmt.Errorf("OVF source requires either URL or Path")
+}
+
+// isOvfSourceOVA reports whether the configured source is an OVA archive.
+func isOvfSourceOVA(config *OvfDeployConfig) bool {
+	if config == nil {
+		return false
+	}
+	if config.Path != "" {
+		return strings.HasSuffix(strings.ToLower(config.Path), ".ova")
+	}
+	if config.URL != "" {
+		u, err := url.Parse(config.URL)
+		if err != nil {
+			return false
+		}
+		return strings.HasSuffix(strings.ToLower(u.Path), ".ova")
+	}
+	return false
+}
 
 // remoteOvfArchive fetches remote OVF/OVA content over HTTP(S) on the Packer
 // host. It handles both OVA (TAR archive) and OVF (multi-file) layouts.
@@ -101,27 +143,7 @@ func (a *remoteOvfArchive) openFromTar(name string) (io.ReadCloser, int64, error
 		return nil, 0, httpOvfFetchError(resp.StatusCode, a.rawURL)
 	}
 
-	tr := tar.NewReader(resp.Body)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			_ = resp.Body.Close()
-			return nil, 0, os.ErrNotExist
-		}
-		if err != nil {
-			_ = resp.Body.Close()
-			return nil, 0, fmt.Errorf("error reading OVA archive: %s", err)
-		}
-
-		matched, matchErr := path.Match(name, path.Base(hdr.Name))
-		if matchErr != nil {
-			_ = resp.Body.Close()
-			return nil, 0, fmt.Errorf("invalid glob pattern '%s': %s", name, matchErr)
-		}
-		if matched {
-			return &ovaEntry{Reader: tr, closer: resp.Body}, hdr.Size, nil
-		}
-	}
+	return openTarEntry(resp.Body, name)
 }
 
 // openFromHTTP fetches a file from the OVF HTTP source.
@@ -147,7 +169,85 @@ func (a *remoteOvfArchive) openFromHTTP(name string) (io.ReadCloser, int64, erro
 	return resp.Body, resp.ContentLength, nil
 }
 
-// ovaEntry wraps a TAR entry reader, closing the underlying HTTP response when done.
+// localOvfArchive opens OVF/OVA content from the local filesystem.
+type localOvfArchive struct {
+	path  string
+	isOva bool
+}
+
+func newLocalOvfArchive(localPath string) (*localOvfArchive, error) {
+	cleaned := filepath.Clean(localPath)
+	if cleaned == "" || cleaned == "." {
+		return nil, fmt.Errorf("local OVF/OVA path is required")
+	}
+	return &localOvfArchive{
+		path:  cleaned,
+		isOva: strings.HasSuffix(strings.ToLower(cleaned), ".ova"),
+	}, nil
+}
+
+// Open opens a named file from the local OVF/OVA source.
+func (a *localOvfArchive) Open(name string) (io.ReadCloser, int64, error) {
+	if a.isOva {
+		return a.openFromTar(name)
+	}
+	return a.openFromFile(name)
+}
+
+func (a *localOvfArchive) openFromTar(name string) (io.ReadCloser, int64, error) {
+	f, err := os.Open(a.path)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to open local OVA '%s': %s", a.path, err)
+	}
+	return openTarEntry(f, name)
+}
+
+func (a *localOvfArchive) openFromFile(name string) (io.ReadCloser, int64, error) {
+	filePath := a.path
+	if name != "" && name != a.path && !filepath.IsAbs(name) {
+		filePath = filepath.Join(filepath.Dir(a.path), name)
+	}
+
+	f, err := os.Open(filepath.Clean(filePath))
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to open local file '%s': %s", filePath, err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, 0, fmt.Errorf("failed to stat local file '%s': %s", filePath, err)
+	}
+	return f, info.Size(), nil
+}
+
+// openTarEntry streams a TAR and returns the first entry whose base name
+// matches the glob pattern given by name. closer is closed when the entry is closed
+// or when no matching entry is found.
+func openTarEntry(closer io.ReadCloser, name string) (io.ReadCloser, int64, error) {
+	tr := tar.NewReader(closer)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			_ = closer.Close()
+			return nil, 0, os.ErrNotExist
+		}
+		if err != nil {
+			_ = closer.Close()
+			return nil, 0, fmt.Errorf("error reading OVA archive: %s", err)
+		}
+
+		matched, matchErr := path.Match(name, path.Base(hdr.Name))
+		if matchErr != nil {
+			_ = closer.Close()
+			return nil, 0, fmt.Errorf("invalid glob pattern '%s': %s", name, matchErr)
+		}
+		if matched {
+			return &ovaEntry{Reader: tr, closer: closer}, hdr.Size, nil
+		}
+	}
+}
+
+// ovaEntry wraps a TAR entry reader, closing the underlying source when done.
 type ovaEntry struct {
 	io.Reader
 	closer io.Closer

--- a/builder/vsphere/driver/ovf_archive_test.go
+++ b/builder/vsphere/driver/ovf_archive_test.go
@@ -1,0 +1,367 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package driver
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLocalOvfArchive_OpenOVF(t *testing.T) {
+	dir := t.TempDir()
+	ovfPath := filepath.Join(dir, "example.ovf")
+	diskPath := filepath.Join(dir, "disk.vmdk")
+
+	if err := os.WriteFile(ovfPath, []byte("<Envelope/>"), 0o644); err != nil {
+		t.Fatalf("write ovf: %s", err)
+	}
+	if err := os.WriteFile(diskPath, []byte("vmdk"), 0o644); err != nil {
+		t.Fatalf("write disk: %s", err)
+	}
+
+	archive, err := newLocalOvfArchive(ovfPath)
+	if err != nil {
+		t.Fatalf("newLocalOvfArchive: %s", err)
+	}
+
+	rc, size, err := archive.Open("")
+	if err != nil {
+		t.Fatalf("Open descriptor: %s", err)
+	}
+	defer rc.Close()
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read descriptor: %s", err)
+	}
+	if string(data) != "<Envelope/>" {
+		t.Fatalf("unexpected descriptor contents: %q", data)
+	}
+	if size != int64(len(data)) {
+		t.Fatalf("unexpected size: got %d want %d", size, len(data))
+	}
+
+	disk, size, err := archive.Open("disk.vmdk")
+	if err != nil {
+		t.Fatalf("Open sibling: %s", err)
+	}
+	defer disk.Close()
+	diskData, err := io.ReadAll(disk)
+	if err != nil {
+		t.Fatalf("read sibling: %s", err)
+	}
+	if string(diskData) != "vmdk" {
+		t.Fatalf("unexpected sibling contents: %q", diskData)
+	}
+	if size != int64(len(diskData)) {
+		t.Fatalf("unexpected sibling size: got %d want %d", size, len(diskData))
+	}
+
+	_, _, err = archive.Open("missing.vmdk")
+	if err == nil {
+		t.Fatal("expected error for missing sibling")
+	}
+}
+
+func TestLocalOvfArchive_OpenOVA(t *testing.T) {
+	dir := t.TempDir()
+	ovaPath := filepath.Join(dir, "example.ova")
+
+	f, err := os.Create(ovaPath)
+	if err != nil {
+		t.Fatalf("create ova: %s", err)
+	}
+	tw := tar.NewWriter(f)
+	files := map[string]string{
+		"example.ovf": "<Envelope/>",
+		"disk.vmdk":   "vmdk-data",
+	}
+	for name, contents := range files {
+		hdr := &tar.Header{
+			Name: name,
+			Mode: 0o644,
+			Size: int64(len(contents)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write header: %s", err)
+		}
+		if _, err := tw.Write([]byte(contents)); err != nil {
+			t.Fatalf("write body: %s", err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %s", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close ova: %s", err)
+	}
+
+	archive, err := newLocalOvfArchive(ovaPath)
+	if err != nil {
+		t.Fatalf("newLocalOvfArchive: %s", err)
+	}
+
+	rc, _, err := archive.Open("*.ovf")
+	if err != nil {
+		t.Fatalf("Open ovf from ova: %s", err)
+	}
+	data, err := io.ReadAll(rc)
+	_ = rc.Close()
+	if err != nil {
+		t.Fatalf("read ovf: %s", err)
+	}
+	if string(data) != "<Envelope/>" {
+		t.Fatalf("unexpected ovf contents: %q", data)
+	}
+
+	disk, _, err := archive.Open("disk.vmdk")
+	if err != nil {
+		t.Fatalf("Open disk from ova: %s", err)
+	}
+	diskData, err := io.ReadAll(disk)
+	_ = disk.Close()
+	if err != nil {
+		t.Fatalf("read disk: %s", err)
+	}
+	if string(diskData) != "vmdk-data" {
+		t.Fatalf("unexpected disk contents: %q", diskData)
+	}
+
+	_, _, err = archive.Open("missing.vmdk")
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected os.ErrNotExist, got %v", err)
+	}
+}
+
+func TestNewOvfArchive_SelectsImplementation(t *testing.T) {
+	dir := t.TempDir()
+	ovfPath := filepath.Join(dir, "example.ovf")
+	if err := os.WriteFile(ovfPath, []byte("<Envelope/>"), 0o644); err != nil {
+		t.Fatalf("write ovf: %s", err)
+	}
+
+	local, err := newOvfArchive(&OvfDeployConfig{Path: ovfPath})
+	if err != nil {
+		t.Fatalf("local archive: %s", err)
+	}
+	if _, ok := local.(*localOvfArchive); !ok {
+		t.Fatalf("expected *localOvfArchive, got %T", local)
+	}
+
+	remote, err := newOvfArchive(&OvfDeployConfig{URL: "https://packages.example.com/artifacts/example.ovf"})
+	if err != nil {
+		t.Fatalf("remote archive: %s", err)
+	}
+	if _, ok := remote.(*remoteOvfArchive); !ok {
+		t.Fatalf("expected *remoteOvfArchive, got %T", remote)
+	}
+
+	_, err = newOvfArchive(&OvfDeployConfig{
+		URL:  "https://packages.example.com/artifacts/example.ovf",
+		Path: ovfPath,
+	})
+	if err == nil || !strings.Contains(err.Error(), "both URL and Path") {
+		t.Fatalf("expected exclusivity error, got %v", err)
+	}
+
+	_, err = newOvfArchive(&OvfDeployConfig{})
+	if err == nil || !strings.Contains(err.Error(), "requires either URL or Path") {
+		t.Fatalf("expected missing source error, got %v", err)
+	}
+}
+
+// TestRemoteOvfArchive_AuthURL tests that newRemoteOvfArchive embeds
+// authentication credentials into the raw URL correctly.
+func TestRemoteOvfArchive_AuthURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		originalURL string
+		auth        *OvfAuthConfig
+		expectedURL string
+		expectError bool
+	}{
+		{
+			name:        "No authentication",
+			originalURL: "https://packages.example.com/artifacts/example.ovf",
+			auth:        nil,
+			expectedURL: "https://packages.example.com/artifacts/example.ovf",
+			expectError: false,
+		},
+		{
+			name:        "Empty authentication",
+			originalURL: "https://packages.example.com/artifacts/example.ovf",
+			auth:        &OvfAuthConfig{},
+			expectedURL: "https://packages.example.com/artifacts/example.ovf",
+			expectError: false,
+		},
+		{
+			name:        "Basic authentication",
+			originalURL: "https://packages.example.com/artifacts/example.ovf",
+			auth: &OvfAuthConfig{
+				Username: "testuser",
+				Password: "testpass",
+			},
+			expectedURL: "https://testuser:testpass@packages.example.com/artifacts/example.ovf",
+			expectError: false,
+		},
+		{
+			name:        "Invalid URL",
+			originalURL: "://invalid-url",
+			auth: &OvfAuthConfig{
+				Username: "testuser",
+				Password: "testpass",
+			},
+			expectedURL: "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			archive, err := newRemoteOvfArchive(tt.originalURL, tt.auth, false)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+				return
+			}
+			if archive.rawURL != tt.expectedURL {
+				t.Errorf("expected rawURL '%s', got '%s'", tt.expectedURL, archive.rawURL)
+			}
+		})
+	}
+}
+
+func TestHttpOvfFetchError(t *testing.T) {
+	const fileURL = "https://user:secret@packages.example.com/artifacts/example.ovf"
+	const sanitized = "https://packages.example.com/artifacts/example.ovf"
+
+	tests := []struct {
+		name           string
+		statusCode     int
+		wantContains   []string
+		wantNotContain string
+	}{
+		{
+			name:         "unauthorized",
+			statusCode:   http.StatusUnauthorized,
+			wantContains: []string{"authentication failed", "(HTTP 401)", sanitized},
+		},
+		{
+			name:         "forbidden",
+			statusCode:   http.StatusForbidden,
+			wantContains: []string{"access denied", "(HTTP 403)", sanitized},
+		},
+		{
+			name:         "not found",
+			statusCode:   http.StatusNotFound,
+			wantContains: []string{"OVF/OVA file not found", "(HTTP 404)", sanitized},
+		},
+		{
+			name:         "gone",
+			statusCode:   http.StatusGone,
+			wantContains: []string{"no longer available", "(HTTP 410)", sanitized},
+		},
+		{
+			name:         "rate limited",
+			statusCode:   http.StatusTooManyRequests,
+			wantContains: []string{"rate-limited", "(HTTP 429)", sanitized},
+		},
+		{
+			name:         "server error",
+			statusCode:   http.StatusInternalServerError,
+			wantContains: []string{"remote server error", "(HTTP 500)", sanitized},
+		},
+		{
+			name:         "unexpected client error",
+			statusCode:   http.StatusBadRequest,
+			wantContains: []string{"unexpected HTTP 400", sanitized},
+		},
+		{
+			name:           "strips credentials from URL",
+			statusCode:     http.StatusNotFound,
+			wantContains:   []string{sanitized},
+			wantNotContain: "secret",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := httpOvfFetchError(tt.statusCode, fileURL)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			msg := err.Error()
+			for _, want := range tt.wantContains {
+				if !strings.Contains(msg, want) {
+					t.Errorf("error %q missing %q", msg, want)
+				}
+			}
+			if tt.wantNotContain != "" && strings.Contains(msg, tt.wantNotContain) {
+				t.Errorf("error %q must not contain %q", msg, tt.wantNotContain)
+			}
+		})
+	}
+}
+
+func TestRemoteOvfArchive_OpenHTTPStatusErrors(t *testing.T) {
+	tests := []struct {
+		name         string
+		statusCode   int
+		wantContains string
+	}{
+		{
+			name:         "unauthorized",
+			statusCode:   http.StatusUnauthorized,
+			wantContains: "authentication failed",
+		},
+		{
+			name:         "not found",
+			statusCode:   http.StatusNotFound,
+			wantContains: "OVF/OVA file not found",
+		},
+		{
+			name:         "forbidden",
+			statusCode:   http.StatusForbidden,
+			wantContains: "access denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer server.Close()
+
+			archive, err := newRemoteOvfArchive(server.URL+"/artifacts/example.ovf", nil, false)
+			if err != nil {
+				t.Fatalf("unexpected error creating archive: %s", err)
+			}
+
+			_, _, err = archive.Open("")
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantContains) {
+				t.Errorf("error %q missing %q", err.Error(), tt.wantContains)
+			}
+			if !strings.Contains(err.Error(), fmt.Sprintf("(HTTP %d)", tt.statusCode)) {
+				t.Errorf("error %q missing HTTP status %d", err.Error(), tt.statusCode)
+			}
+		})
+	}
+}

--- a/builder/vsphere/driver/ovf_network_test.go
+++ b/builder/vsphere/driver/ovf_network_test.go
@@ -1,0 +1,105 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package driver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestBuildOvfNetworkMappings(t *testing.T) {
+	sim, err := NewVCenterSimulator()
+	if err != nil {
+		t.Fatalf("unexpected error creating simulator: %s", err)
+	}
+	defer sim.Close()
+
+	driver := sim.driver
+
+	tests := []struct {
+		name         string
+		ovfNetworks  []types.OvfNetworkInfo
+		network      string
+		expectError  bool
+		errorMsg     string
+		expectMapped int
+		expectNames  []string
+	}{
+		{
+			name:         "No OVF networks",
+			ovfNetworks:  nil,
+			network:      "VM Network",
+			expectMapped: 0,
+		},
+		{
+			name: "Single OVF network mapped",
+			ovfNetworks: []types.OvfNetworkInfo{
+				{Name: "Management Network"},
+			},
+			network:      "VM Network",
+			expectMapped: 1,
+			expectNames:  []string{"Management Network"},
+		},
+		{
+			name: "Multiple OVF networks mapped to same vSphere network",
+			ovfNetworks: []types.OvfNetworkInfo{
+				{Name: "Management Network"},
+				{Name: "VM Network"},
+			},
+			network:      "VM Network",
+			expectMapped: 2,
+			expectNames:  []string{"Management Network", "VM Network"},
+		},
+		{
+			name: "OVF networks require configured network",
+			ovfNetworks: []types.OvfNetworkInfo{
+				{Name: "Guest Network"},
+			},
+			network:     "",
+			expectError: true,
+			errorMsg:    "OVF requires network mapping",
+		},
+		{
+			name: "Invalid vSphere network",
+			ovfNetworks: []types.OvfNetworkInfo{
+				{Name: "Guest Network"},
+			},
+			network:     "nonexistent-network",
+			expectError: true,
+			errorMsg:    "error finding network",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mappings, err := driver.buildOvfNetworkMappings(tt.ovfNetworks, tt.network)
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				if tt.errorMsg != "" && !strings.Contains(err.Error(), tt.errorMsg) {
+					t.Fatalf("expected error containing %q, got %q", tt.errorMsg, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if len(mappings) != tt.expectMapped {
+				t.Fatalf("expected %d network mappings, got %d", tt.expectMapped, len(mappings))
+			}
+
+			for i, expectedName := range tt.expectNames {
+				if mappings[i].Name != expectedName {
+					t.Errorf("mapping[%d].Name = %q, want %q", i, mappings[i].Name, expectedName)
+				}
+			}
+		})
+	}
+}

--- a/builder/vsphere/driver/ovf_sanitize.go
+++ b/builder/vsphere/driver/ovf_sanitize.go
@@ -22,6 +22,15 @@ func SanitizeOvfURL(urlStr string) string {
 	return u.String()
 }
 
+// SanitizeOvfSource returns a safe label for an OVF source. HTTP(S) URLs have
+// credentials stripped; local filesystem paths are returned unchanged.
+func SanitizeOvfSource(urlStr, pathStr string) string {
+	if pathStr != "" {
+		return pathStr
+	}
+	return SanitizeOvfURL(urlStr)
+}
+
 // SanitizeOvfErrorMessage removes sensitive information from error messages.
 func SanitizeOvfErrorMessage(errMsg string) string {
 	sanitized := sanitizeOvfURLsInString(errMsg)

--- a/builder/vsphere/driver/ovf_sanitize_test.go
+++ b/builder/vsphere/driver/ovf_sanitize_test.go
@@ -1,0 +1,125 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package driver
+
+import (
+	"testing"
+)
+
+// TestSanitizeOvfErrorMessage tests the sanitization of sensitive information in error messages.
+func TestSanitizeOvfErrorMessage(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "URL with credentials",
+			input:    "error accessing https://user:password@packages.example.com/artifacts/example.ovf",
+			expected: "error accessing https://packages.example.com/artifacts/example.ovf",
+		},
+		{
+			name:     "Password in error message",
+			input:    "authentication failed: password=testpass",
+			expected: "authentication failed: [credentials removed]",
+		},
+		{
+			name:     "Multiple credential patterns",
+			input:    "failed with password=secret and token=abc123",
+			expected: "failed with [credentials removed] and [credentials removed]",
+		},
+		{
+			name:     "No credentials to sanitize",
+			input:    "network timeout error",
+			expected: "network timeout error",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := SanitizeOvfErrorMessage(tc.input)
+			if result != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, result)
+			}
+		})
+	}
+}
+
+// TestSanitizeOvfURL tests the sanitization of credentials from URLs.
+func TestSanitizeOvfURL(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "URL with username and password",
+			input:    "https://testuser:testpass@packages.example.com/artifacts/example.ovf",
+			expected: "https://packages.example.com/artifacts/example.ovf",
+		},
+		{
+			name:     "URL without credentials",
+			input:    "https://packages.example.com/artifacts/example.ovf",
+			expected: "https://packages.example.com/artifacts/example.ovf",
+		},
+		{
+			name:     "Relative URL without credentials",
+			input:    "not-a-url",
+			expected: "not-a-url",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := SanitizeOvfURL(tc.input)
+			if result != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestSanitizeOvfSource(t *testing.T) {
+	tests := []struct {
+		name     string
+		urlStr   string
+		pathStr  string
+		expected string
+	}{
+		{
+			name:     "path takes precedence",
+			urlStr:   "https://user:pass@packages.example.com/artifacts/example.ovf",
+			pathStr:  "./artifacts/example.ova",
+			expected: "./artifacts/example.ova",
+		},
+		{
+			name:     "url with credentials stripped",
+			urlStr:   "https://user:pass@packages.example.com/artifacts/example.ovf",
+			pathStr:  "",
+			expected: "https://packages.example.com/artifacts/example.ovf",
+		},
+		{
+			name:     "url without credentials",
+			urlStr:   "https://packages.example.com/artifacts/example.ovf",
+			pathStr:  "",
+			expected: "https://packages.example.com/artifacts/example.ovf",
+		},
+		{
+			name:     "empty path and empty url",
+			urlStr:   "",
+			pathStr:  "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeOvfSource(tt.urlStr, tt.pathStr)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}

--- a/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/CloneConfig-not-required.mdx
@@ -3,16 +3,16 @@
 - `template` (string) - The name of the source virtual machine template to clone. Specify either
   `template` or `ovf_source`, but not both.
 
-- `ovf_source` (\*OvfSourceConfig) - Configuration for deploying from an OVF/OVA source accessible using
-  HTTP or HTTPS. Conflicts with `template`.
+- `ovf_source` (\*OvfSourceConfig) - Configuration for deploying from an OVF/OVA source. Specify either a
+  remote `url` or a local `path`. Conflicts with `template`.
   
-  HTTP
+  Local
   
   HCL Example:
   
   ```hcl
   ovf_source {
-    url = "http://packages.example.com/templates/example.ovf"
+    path = "./artifacts/example.ovf"
   }
   ```
   
@@ -20,17 +20,19 @@
   
   ```json
   "ovf_source": {
-    "url": "http://packages.example.com/templates/example.ovf"
+    "path": "./artifacts/example.ovf"
   }
   ```
   
-  HTTPS
+  -> **Note:** The `path` must end in `.ovf` or `.ova`.
+  
+  Remote
   
   HCL Example:
   
   ```hcl
   ovf_source {
-    url = "https://packages.example.com/templates/example.ovf"
+    url = "https://packages.example.com/artifacts/example.ovf"
   }
   ```
   
@@ -38,17 +40,18 @@
   
   ```json
   "ovf_source": {
-    "url": "https://packages.example.com/templates/example.ovf"
+    "url": "https://packages.example.com/artifacts/example.ovf"
   }
   ```
   
-  HTTPS and Basic Authentication
+  -> **Note:** Use `http://` or `https://`. The `url` must end in `.ovf`
+  or `.ova`.
   
   HCL Example:
   
   ```hcl
   ovf_source {
-    url             = "https://packages.example.com/artifacts/example.ovf"
+    url             = "https://packages.example.com/artifacts/example.ova"
     username        = "ovf_source_username"
     password        = "ovf_source_password"
     skip_tls_verify = false
@@ -59,7 +62,7 @@
   
   ```json
   "ovf_source": {
-    "url": "https://packages.example.com/artifacts/example.ovf",
+    "url": "https://packages.example.com/artifacts/example.ova",
     "username": "ovf_source_username",
     "password": "ovf_source_password",
     "skip_tls_verify": false
@@ -68,6 +71,9 @@
   
   -> **Note:** For credentials, use variables marked `sensitive = true` for
   `username` and `password`.
+  
+  -> **Note:** When using a multi-file OVF, keep the descriptor and its disk
+  files in the same directory on the local and remote sources.
 
 - `disk_size` (int64) - The size of the primary disk in MiB. Conflicts with `linked_clone`.
   

--- a/docs-partials/builder/vsphere/clone/OvfSourceConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/clone/OvfSourceConfig-not-required.mdx
@@ -1,15 +1,19 @@
 <!-- Code generated from the comments of the OvfSourceConfig struct in builder/vsphere/clone/step_clone.go; DO NOT EDIT MANUALLY -->
 
 - `url` (string) - The URL of the remote OVF/OVA file. Supports HTTP and HTTPS protocols.
+  Conflicts with `path`.
+
+- `path` (string) - The path to a local OVF/OVA file on the host filesystem.
+  Conflicts with `url`.
 
 - `username` (string) - The username for basic authentication when accessing the remote OVF/OVA file.
-  Must be used together with `password`.
+  Must be used together with `password`. Only applicable when `url` is set.
 
 - `password` (string) - The password for basic authentication when accessing the remote OVF/OVA file.
-  Must be used together with `username`.
+  Must be used together with `username`. Only applicable when `url` is set.
 
 - `skip_tls_verify` (bool) - Do not validate the certificate when accessing HTTPS URLs.
-  Defaults to `false`.
+  Defaults to `false`. Only applicable when `url` is set.
   
   -> **Note:** This option is beneficial in scenarios where the certificate
   is self-signed or does not meet standard validation criteria.

--- a/docs-partials/builder/vsphere/common/StorageConfig.mdx
+++ b/docs-partials/builder/vsphere/common/StorageConfig.mdx
@@ -4,10 +4,11 @@ When cloning from a `template`, the resulting virtual machine contains the
 source template's disks plus any newly configured disks and controllers.
 `storage {}`, `disk_controller_type`, and `disk_size` apply in this mode.
 
-When deploying from `ovf_source`, the plugin downloads the OVF/OVA package
-on the Packer host and imports it into vSphere using the OVF Manager and an
-NFC lease upload. Virtual disks, how many, how large, and how they are
-provisioned (for example, thin or thick) are provided by the OVF/OVA descriptor.
+When deploying from `ovf_source`, the plugin reads the OVF/OVA package on
+the Packer host (from an HTTP(S) URL or a local filesystem `path`) and
+imports it into vSphere using the OVF Manager and an NFC lease upload.
+Virtual disks, how many, how large, and how they are provisioned (for
+example, thin or thick) are provided by the OVF/OVA descriptor.
 When the descriptor offers multiple deployment sizes, use `vapp.deployment_option`
 to select one. For more information, refer to the [vApp Options Configuration](#vapp-options-configuration)
 section.

--- a/docs-site/scripts/lib/format-example-labels.sh
+++ b/docs-site/scripts/lib/format-example-labels.sh
@@ -59,7 +59,7 @@ format_example_labels() {
 
     sub example_section_heading_on_line {
       my ($line) = @_;
-      if ($line =~ /^(\s{2,})(?:\*\*)?(HTTP|HTTPS(?: and Basic Authentication)?)(?:\*\*)?\s*$/) {
+      if ($line =~ /^(\s{2,})(?:\*\*)?(Local|Remote)(?:\*\*)?\s*$/) {
         return ($1, $2);
       }
       return;

--- a/docs-site/scripts/test/test-format-example-labels.sh
+++ b/docs-site/scripts/test/test-format-example-labels.sh
@@ -316,16 +316,16 @@ EOF
 test_ovf_source_section_headings() {
   local input
   input="$(cat <<'EOF'
-- `ovf_source` (*OvfSourceConfig) - Configuration for deploying from a remote OVF/OVA source accessible using
-  HTTP or HTTPS. Conflicts with `template`.
+- `ovf_source` (*OvfSourceConfig) - Configuration for deploying from an OVF/OVA source. Specify either a
+  remote `url` or a local `path`. Conflicts with `template`.
 
-  HTTP
+  Local
 
   HCL Example:
 
   ```hcl
   ovf_source {
-    url = "http://example.com/example.ovf"
+    path = "./artifacts/example.ovf"
   }
   ```
 
@@ -333,16 +333,35 @@ test_ovf_source_section_headings() {
 
   ```json
   "ovf_source": {
-    "url": "http://example.com/example.ovf"
+    "path": "./artifacts/example.ovf"
+  }
+  ```
+
+  Remote
+
+  HCL Example:
+
+  ```hcl
+  ovf_source {
+    url = "https://example.com/example.ovf"
+  }
+  ```
+
+  JSON Example:
+
+  ```json
+  "ovf_source": {
+    "url": "https://example.com/example.ovf"
   }
   ```
 EOF
 )"
   local output
   output="$(format_example_labels "$input")"
-  assert_contains "$output" $'template`.\n\n    **HTTP**' "section heading on its own line"
-  assert_not_contains "$output" $'template`. **HTTP**' "section heading not inline with description"
-  assert_contains "$output" $'    **HTTP**\n\n    **HCL Example:**' "blank before hcl example after section heading"
+  assert_contains "$output" $'template`.\n\n    **Local**' "section heading on its own line"
+  assert_not_contains "$output" $'template`. **Local**' "section heading not inline with description"
+  assert_contains "$output" $'    **Local**\n\n    **HCL Example:**' "blank before hcl example after local heading"
+  assert_contains "$output" $'    **Remote**\n\n    **HCL Example:**' "blank before hcl example after remote heading"
 }
 
 main() {


### PR DESCRIPTION

<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

> [!NOTE]
> Targeted for milestone v2.3.0.

Extends the `vsphere-clone` builder's `ovf_source` block to support local OVF/OVA files using `path`, alongside the existing remote OVF/OVA using `url` and related arguments..

Local OVF/OVA support lets users deploy virtual machines from `.ovf` (with sibling disks) or `.ova` archives on the host filesystem.

- Adds `path` to `ovf_source`, mutually exclusive with `url`.
- Requires the file to exist at prepare time; reject auth/TLS options when using `path`.
- Adds shared OVF archive abstraction (remote + local) used by deploy and options validation.
- Emits `ource_ovf_path` artifact metadata for local sources.
- Updates documentation and related scripts on in-repo documentation.
- Moves all OVF helper tests alongside the code in `ovf_*_test.go` files.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [x] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been added or updated.
- [x] Tests have been completed.

  ✅ All added or updated unit tests have passed.

  ✅ All manual tests have passed.
  
     - Clone from local OVA from absolute path.
     - Clone from local OVA from relative path.
     - Clone from local OVF from absolute path.
     - Clone from local OVF from relative path.
     - Clone from local OVA with vApp Properties.
     - Clone from local OVF with vApp Properties.
     - Additionally, negative testing for expected conflicts and error messages.
     - Remote OVF/OVA regression testing.

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [x] Documentation has been added or updated.

<img width="747" height="1024" alt="image" src="https://github.com/user-attachments/assets/1f8aee3e-415b-42a8-b60c-e114b6580e76" />


### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

Closes #567

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->