### PR TITLE
chore(release): v2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ packer {
   required_version = ">= 1.7.0"
   required_plugins {
     vmware = {
-      version = ">= 2.2.0"
+      version = ">= 2.3.0"
       source  = "github.com/vmware/vsphere"
     }
   }
@@ -87,7 +87,7 @@ Examples:
 2. Install a specific version of the plugin:
 
     ```shell
-    packer plugins install github.com/vmware/vsphere@v2.2.0
+    packer plugins install github.com/vmware/vsphere@v2.3.0
     ```
 
 ### Using the Source

--- a/version/version.go
+++ b/version/version.go
@@ -8,7 +8,7 @@ import "github.com/hashicorp/packer-plugin-sdk/version"
 
 var (
 	Version           = "2.3.0"
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 	VersionMetadata   = ""
 	PluginVersion     = version.NewPluginVersion(Version, VersionPrerelease, VersionMetadata)
 )


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

Release v2.3.0.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [x] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [x] Tests have been completed.

Output:

```shell
packer-plugin-vsphere on  main [$] via 🐹 v1.26.4 via 🅐 v2.21.2 
➜ make test
go: downloading github.com/vmware/govmomi v0.55.1
go: downloading golang.org/x/mobile v0.0.0-20260519152538-35b1249819c3
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/vmware-tanzu/image-registry-operator-api v0.0.0-20240422225856-ad6a4cd477e0
go: downloading github.com/vmware-tanzu/vm-operator/api v1.8.7-0.20250406160248-af0c660a6ede
go: downloading gopkg.in/yaml.v2 v2.4.0
go: downloading k8s.io/api v0.31.0
go: downloading k8s.io/apimachinery v0.31.0
go: downloading k8s.io/client-go v0.31.0
go: downloading sigs.k8s.io/controller-runtime v0.19.0
go: downloading github.com/hashicorp/go-version v1.6.0
go: downloading gopkg.in/inf.v0 v0.9.1
go: downloading k8s.io/klog/v2 v2.130.1
go: downloading github.com/gogo/protobuf v1.3.2
go: downloading github.com/google/gofuzz v1.2.0
go: downloading github.com/onsi/gomega v1.33.1
go: downloading k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
go: downloading sigs.k8s.io/structured-merge-diff/v4 v4.4.1
go: downloading golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc
go: downloading sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd
go: downloading github.com/fxamacker/cbor/v2 v2.7.0
go: downloading github.com/evanphx/json-patch/v5 v5.9.0
go: downloading sigs.k8s.io/yaml v1.4.0
go: downloading k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340
go: downloading github.com/x448/float16 v0.8.4
go: downloading github.com/json-iterator/go v1.1.12
go: downloading github.com/modern-go/reflect2 v1.0.2
go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: downloading github.com/spf13/pflag v1.0.5
go: downloading github.com/imdario/mergo v0.3.12
go: downloading github.com/google/gnostic-models v0.6.8
go: downloading github.com/golang/protobuf v1.5.4
go: downloading github.com/go-openapi/swag v0.22.4
go: downloading github.com/go-openapi/jsonreference v0.20.2
go: downloading github.com/emicklei/go-restful/v3 v3.11.0
go: downloading github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
go: downloading github.com/go-openapi/jsonpointer v0.19.6
go: downloading github.com/mailru/easyjson v0.7.7
go: downloading github.com/josharian/intern v1.0.0
go: downloading gopkg.in/evanphx/json-patch.v4 v4.12.0
?       github.com/vmware/packer-plugin-vsphere [no test files]
ok      github.com/vmware/packer-plugin-vsphere/builder/vsphere/clone   1.893s
ok      github.com/vmware/packer-plugin-vsphere/builder/vsphere/common  3.355s
ok      github.com/vmware/packer-plugin-vsphere/builder/vsphere/driver  13.161s
ok      github.com/vmware/packer-plugin-vsphere/builder/vsphere/iso     4.752s
ok      github.com/vmware/packer-plugin-vsphere/builder/vsphere/supervisor      8.296s
ok      github.com/vmware/packer-plugin-vsphere/datasource/common       5.893s
ok      github.com/vmware/packer-plugin-vsphere/datasource/computecluster       5.785s
ok      github.com/vmware/packer-plugin-vsphere/datasource/contentlibrary       3.007s
ok      github.com/vmware/packer-plugin-vsphere/datasource/contentlibraryitem   6.449s
ok      github.com/vmware/packer-plugin-vsphere/datasource/datastore    5.021s
ok      github.com/vmware/packer-plugin-vsphere/datasource/datastorecluster     4.660s
ok      github.com/vmware/packer-plugin-vsphere/datasource/host 7.310s
ok      github.com/vmware/packer-plugin-vsphere/datasource/network      6.980s
ok      github.com/vmware/packer-plugin-vsphere/datasource/resourcepool 5.202s
ok      github.com/vmware/packer-plugin-vsphere/datasource/virtualmachine       7.082s
ok      github.com/vmware/packer-plugin-vsphere/post-processor/vsphere  3.724s
ok      github.com/vmware/packer-plugin-vsphere/post-processor/vsphere-template 4.286s
?       github.com/vmware/packer-plugin-vsphere/testing/acceptance      [no test files]
ok      github.com/vmware/packer-plugin-vsphere/testing/env     4.119s
?       github.com/vmware/packer-plugin-vsphere/testing/vcsim   [no test files]
?       github.com/vmware/packer-plugin-vsphere/version [no test files]

packer-plugin-vsphere on  main [$] via 🐹 v1.26.4 via 🅐 v2.21.2 took 14.5s 
➜ make testacc-datasource
testing: warning: no tests to run
PASS
ok      github.com/vmware/packer-plugin-vsphere/datasource/common       0.261s [no tests to run]
=== RUN   TestAccDatasourceComputeCluster
--- PASS: TestAccDatasourceComputeCluster (0.15s)
PASS
ok      github.com/vmware/packer-plugin-vsphere/datasource/computecluster       0.535s
=== RUN   TestAccDatasourceContentLibrary
--- PASS: TestAccDatasourceContentLibrary (0.62s)
PASS
ok      github.com/vmware/packer-plugin-vsphere/datasource/contentlibrary       1.354s
=== RUN   TestAccDatasourceContentLibraryItem
=== RUN   TestAccDatasourceContentLibraryItem/VMTX
=== RUN   TestAccDatasourceContentLibraryItem/OVF
--- PASS: TestAccDatasourceContentLibraryItem (1.56s)
    --- PASS: TestAccDatasourceContentLibraryItem/VMTX (0.94s)
    --- PASS: TestAccDatasourceContentLibraryItem/OVF (0.62s)
PASS
ok      github.com/vmware/packer-plugin-vsphere/datasource/contentlibraryitem   2.652s
=== RUN   TestAccDatasourceDatastore
--- PASS: TestAccDatasourceDatastore (0.20s)
PASS
ok      github.com/vmware/packer-plugin-vsphere/datasource/datastore    1.988s
=== RUN   TestAccDatasourceDatastoreCluster
--- PASS: TestAccDatasourceDatastoreCluster (0.18s)
PASS
ok      github.com/vmware/packer-plugin-vsphere/datasource/datastorecluster     2.310s
=== RUN   TestAccDatasourceHost
--- PASS: TestAccDatasourceHost (0.33s)
PASS
ok      github.com/vmware/packer-plugin-vsphere/datasource/host 1.760s
=== RUN   TestAccDatasourceNetwork
--- PASS: TestAccDatasourceNetwork (0.18s)
PASS
ok      github.com/vmware/packer-plugin-vsphere/datasource/network      2.658s
=== RUN   TestAccDatasourceResourcePool
--- PASS: TestAccDatasourceResourcePool (0.19s)
PASS
ok      github.com/vmware/packer-plugin-vsphere/datasource/resourcepool 3.019s
=== RUN   TestAccDatasourceVirtualMachine
--- PASS: TestAccDatasourceVirtualMachine (0.17s)
PASS
ok      github.com/vmware/packer-plugin-vsphere/datasource/virtualmachine       3.363s

packer-plugin-vsphere on  main [$] via 🐹 v1.26.4 via 🅐 v2.21.2 took 4.6s 
➜ make testacc-builder-clone
packer plugins install --path packer-plugin-vsphere "github.com/vmware/vsphere"
Successfully installed plugin github.com/vmware/vsphere from /Users/ryan/Library/Mobile Documents/com~apple~CloudDocs/Code/packer-plugin-vsphere/packer-plugin-vsphere to /Users/ryan/.packer.d/plugins/github.com/vmware/vsphere/packer-plugin-vsphere_v2.3.0-dev_x5.0_darwin_arm64
=== RUN   TestAccCloneBuilder_MatrixA
--- PASS: TestAccCloneBuilder_MatrixA (5.48s)
=== RUN   TestAccCloneBuilder_MatrixB
--- PASS: TestAccCloneBuilder_MatrixB (8.05s)
=== RUN   TestAccCloneBuilder_MatrixC
--- PASS: TestAccCloneBuilder_MatrixC (60.51s)
=== RUN   TestAccCloneBuilder_MatrixD
    builder_acc_test.go:451: set VSPHERE_OVA_URL to an HTTPS .ova URL to run this ACC row
--- SKIP: TestAccCloneBuilder_MatrixD (0.00s)
=== RUN   TestAccCloneBuilder_MatrixE
    builder_acc_test.go:483: set VSPHERE_OVA_URL to an HTTPS .ova URL to run this ACC row
--- SKIP: TestAccCloneBuilder_MatrixE (0.00s)
=== RUN   TestAccCloneBuilder_MatrixF
    builder_acc_test.go:515: set VSPHERE_OVF_URL to an HTTPS .ovf URL to run this ACC row
--- SKIP: TestAccCloneBuilder_MatrixF (0.00s)
=== RUN   TestAccCloneBuilder_MatrixG
    builder_acc_test.go:544: set VSPHERE_OVA_URL to an HTTPS .ova URL to run this ACC row
--- SKIP: TestAccCloneBuilder_MatrixG (0.00s)
PASS
ok      github.com/vmware/packer-plugin-vsphere/builder/vsphere/clone   74.672s

packer-plugin-vsphere on  main [$] via 🐹 v1.26.4 via 🅐 v2.21.2 
➜ export VSPHERE_OVA_URL="https://192.168.86.254/vcf-offline-depot-appliance-1.0.0.ova"
export VSPHERE_OVF_URL="https://192.168.86.254/vcf-offline-depot-appliance-1.0.0.ovf"
export VSPHERE_OVF_USERNAME='vcf'
export VSPHERE_OVF_PASSWORD='VMw@re1!'
export VSPHERE_OVF_SKIP_TLS_VERIFY="1"

packer-plugin-vsphere on  main [$] via 🐹 v1.26.4 via 🅐 v2.21.2 
➜ make testacc-builder-clone
packer plugins install --path packer-plugin-vsphere "github.com/vmware/vsphere"
Successfully installed plugin github.com/vmware/vsphere from /Users/ryan/Library/Mobile Documents/com~apple~CloudDocs/Code/packer-plugin-vsphere/packer-plugin-vsphere to /Users/ryan/.packer.d/plugins/github.com/vmware/vsphere/packer-plugin-vsphere_v2.3.0-dev_x5.0_darwin_arm64
=== RUN   TestAccCloneBuilder_MatrixA
--- PASS: TestAccCloneBuilder_MatrixA (6.68s)
=== RUN   TestAccCloneBuilder_MatrixB
--- PASS: TestAccCloneBuilder_MatrixB (7.46s)
=== RUN   TestAccCloneBuilder_MatrixC
--- PASS: TestAccCloneBuilder_MatrixC (62.40s)
=== RUN   TestAccCloneBuilder_MatrixD
--- PASS: TestAccCloneBuilder_MatrixD (99.35s)
=== RUN   TestAccCloneBuilder_MatrixE
--- PASS: TestAccCloneBuilder_MatrixE (101.03s)
=== RUN   TestAccCloneBuilder_MatrixF
--- PASS: TestAccCloneBuilder_MatrixF (91.58s)
=== RUN   TestAccCloneBuilder_MatrixG
--- PASS: TestAccCloneBuilder_MatrixG (94.19s)
PASS
ok      github.com/vmware/packer-plugin-vsphere/builder/vsphere/clone   463.371s

packer-plugin-vsphere on  main [$] via 🐹 v1.26.4 via 🅐 v2.21.2 took 7m 46.9s 
➜ make testacc-builder-iso  
packer plugins install --path packer-plugin-vsphere "github.com/vmware/vsphere"
Successfully installed plugin github.com/vmware/vsphere from /Users/ryan/Library/Mobile Documents/com~apple~CloudDocs/Code/packer-plugin-vsphere/packer-plugin-vsphere to /Users/ryan/.packer.d/plugins/github.com/vmware/vsphere/packer-plugin-vsphere_v2.3.0-dev_x5.0_darwin_arm64
=== RUN   TestAccISOBuilder_MatrixA
--- PASS: TestAccISOBuilder_MatrixA (355.95s)
=== RUN   TestAccISOBuilder_MatrixB
--- PASS: TestAccISOBuilder_MatrixB (359.09s)
=== RUN   TestAccISOBuilder_MatrixC
2026/08/03 12:24:18 [INFO] Resolved content library item 'acc-test-20260803-121758-vm-template' (type=vm-template) in library 'lib01'
2026/08/03 12:24:19 [INFO] Resolved content library item 'acc-test-20260803-121758-vm-template' (type=vm-template) in library 'lib01'
--- PASS: TestAccISOBuilder_MatrixC (382.09s)
=== RUN   TestAccISOBuilder_MatrixD
2026/08/03 12:31:29 [INFO] Resolved content library item 'acc-test-20260803-122420-ovf-template' (type=ovf) in library 'lib01'
2026/08/03 12:31:30 [INFO] Resolved content library item 'acc-test-20260803-122420-ovf-template' (type=ovf) in library 'lib01'
--- PASS: TestAccISOBuilder_MatrixD (430.73s)
PASS
ok      github.com/vmware/packer-plugin-vsphere/builder/vsphere/iso     1528.591s
```

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [x] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->