### PR TITLE
fix: prevent artifact cleanup from crashing the rpc boundary on destroy failure

### DIFF
--- a/builder/vsphere/common/artifact.go
+++ b/builder/vsphere/common/artifact.go
@@ -119,11 +119,16 @@ func (a *Artifact) stateHCPPackerRegistryMetadata() interface{} {
 	return img
 }
 
+// Destroy removes the output directory (if any) and destroys the source
+// virtual machine.
 func (a *Artifact) Destroy() error {
 	if a.Outconfig != nil {
 		if err := os.RemoveAll(a.Outconfig.OutputDir); err != nil {
 			log.Printf("[WARN] Failed to remove output directory: %v", err)
 		}
 	}
-	return a.VM.Destroy()
+	if err := a.VM.Destroy(); err != nil {
+		log.Printf("[WARN] Failed to destroy virtual machine %q: %v", a.Name, err)
+	}
+	return nil
 }

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -576,10 +576,12 @@ func (vm *VirtualMachineDriver) Properties(ctx context.Context) (*mo.VirtualMach
 func (vm *VirtualMachineDriver) Destroy() error {
 	task, err := vm.vm.Destroy(vm.driver.Ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("error destroying virtual machine: %s", err)
 	}
-	_, err = task.WaitForResult(vm.driver.Ctx, nil)
-	return err
+	if _, err = task.WaitForResult(vm.driver.Ctx, nil); err != nil {
+		return fmt.Errorf("error destroying virtual machine: %s", err)
+	}
+	return nil
 }
 
 // Unregister removes the virtual machine from inventory without deleting its


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

`Artifact.Destroy()` returned the VM destroy error directly, but Packer core's RPC client decodes `Destroy() `replies into a bare `error` interface over msgpack. That codec cannot reconstruct a concrete error type behind an interface, so any non-nil error here surfaces to users as an opaque failure instead of the cause:

```
Error destroying builder artifact: reading body msgpack decode error [pos ...]: reflect.Set: 
value of type map[interface {}] interface {} is not assignable to type error; bad artifact: []string(nil)
```

This reproduces whenever a post-processor causes Packer to destroy the builder's VM artifact and that destroy fails for any reason - observered previously in #279 and also in a new post-processor that I'm developing outside of this project.

Log destroy failures instead of propagating them across the RPC boundary, and wrap the underlying govmomi task error in `VirtualMachineDriver.Destroy` so any future logging carries a plain, serializable error message rather than the raw `task.Error`.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [x] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [ ] Tests have been added or updated.
- [x] Tests have been completed.

Output:

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

Resolves #279

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->