### PR TITLE
feat: add disk controller unit in clone

### DIFF
--- a/.web-docs/components/builder/vsphere-clone/README.md
+++ b/.web-docs/components/builder/vsphere-clone/README.md
@@ -355,21 +355,29 @@ disks are stored.
 
 - `disk_controller_index` (int) - The assigned disk controller for the disk.
   Defaults to the first controller, `(0)`.
+  Mutually exclusive with `disk_controller_unit`.
+
+- `disk_controller_unit` (string) - Explicit controller address for the disk when cloning from a `template`
+  or deploying a VM template `content_library_source`.
+  Format: `{type}{bus}:{unit}` such as `scsi0:1`, `nvme0:0`, or `sata0:2`.
+  Only supported by the `vsphere-clone` builder. Mutually exclusive with
+  `disk_controller_index`.
 
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->
 
 
-The following example creates a 15GB and a 20GB disk on the virtual machine.
-The second disk is thin provisioned:
+The following example creates a 10 GiB (15360 MiB) disk and a 20 GiB
+(20480 MiB) disk on the virtual machine. The second disk is thin
+provisioned:
 
 HCL Example:
 
 ```hcl
 storage {
-  disk_size = 15000
+  disk_size = 10240
 }
 storage {
-  disk_size             = 20000
+  disk_size             = 20480
   disk_thin_provisioned = true
 }
 ```
@@ -379,14 +387,262 @@ JSON Example:
 ```json
 "storage": [
   {
-    "disk_size": 15000
+    "disk_size": 10240
   },
   {
-    "disk_size": 20000,
+    "disk_size": 20480,
     "disk_thin_provisioned": true
   }
 ]
 ```
+
+The following example adds disks to an existing template controller at explicit
+units without creating a new controller. `disk_controller_type` only matters
+when a new controller must be created, so it is not required here, since
+every address (`scsi0:1`, `scsi0:2`) targets a bus that already exists on the
+template:
+
+HCL Example:
+
+```hcl
+storage {
+  disk_size            = 10240
+  disk_controller_unit = "scsi0:1"
+}
+storage {
+  disk_size            = 20480
+  disk_controller_unit = "scsi0:2"
+}
+```
+
+JSON Example:
+
+```json
+"storage": [
+  {
+    "disk_size": 10240,
+    "disk_controller_unit": "scsi0:1"
+  },
+  {
+    "disk_size": 20480,
+    "disk_controller_unit": "scsi0:2"
+  }
+]
+```
+
+~> **Note:** `disk_controller_unit` is only supported by the `vsphere-clone`
+builder when cloning from a `template` or deploying a VM template
+`content_library_source` (the "Template-backed" group in
+[Source Compatibility](#source-compatibility)). It is mutually exclusive with
+`disk_controller_index` on the same `storage` block.
+
+When every `storage` block uses `disk_controller_unit` and some addresses
+reference controllers that do not exist on the template, add matching entries
+to `disk_controller_type` for on-demand controller creation. The first entry
+creates the controller for the first missing bus, and so on.
+
+HCL Example:
+
+```hcl
+disk_controller_type = ["pvscsi"]
+storage {
+  disk_size            = 10240
+  disk_controller_unit = "scsi1:0"
+}
+```
+
+JSON Example:
+
+```json
+"disk_controller_type": ["pvscsi"],
+"storage": [
+  {
+    "disk_size": 10240,
+    "disk_controller_unit": "scsi1:0"
+  }
+]
+```
+
+The following example combines legacy `disk_controller_index` placement with
+explicit `disk_controller_unit` addresses in one clone. When any storage block
+uses `disk_controller_index`, every entry in `disk_controller_type` is created
+as a new controller before explicit disks are attached. On-demand controller
+creation for explicit units then uses any additional `disk_controller_type`
+entries beyond that initial list.
+
+HCL Example:
+
+```hcl
+disk_controller_type = ["pvscsi", "pvscsi"]
+storage {
+  disk_size             = 10240
+  disk_controller_index = 0
+}
+storage {
+  disk_size            = 20480
+  disk_controller_unit = "scsi0:1"
+}
+```
+
+JSON Example:
+
+```json
+"disk_controller_type": ["pvscsi", "pvscsi"],
+"storage": [
+  {
+    "disk_size": 10240,
+    "disk_controller_index": 0
+  },
+  {
+    "disk_size": 20480,
+    "disk_controller_unit": "scsi0:1"
+  }
+]
+```
+
+The following example extends a template that already has `scsi0` and `scsi1`,
+attaches disks to existing controllers at explicit units, and creates a new
+`scsi2` controller for an additional disk:
+
+HCL Example:
+
+```hcl
+disk_controller_type = ["pvscsi"]
+storage {
+  disk_size            = 10240
+  disk_controller_unit = "scsi0:1"
+}
+storage {
+  disk_size            = 20480
+  disk_controller_unit = "scsi1:0"
+}
+storage {
+  disk_size            = 40960
+  disk_controller_unit = "scsi2:0"
+}
+```
+
+JSON Example:
+
+```json
+"disk_controller_type": ["pvscsi"],
+"storage": [
+  {
+    "disk_size": 10240,
+    "disk_controller_unit": "scsi0:1"
+  },
+  {
+    "disk_size": 20480,
+    "disk_controller_unit": "scsi1:0"
+  },
+  {
+    "disk_size": 40960,
+    "disk_controller_unit": "scsi2:0"
+  }
+]
+```
+
+~> **Note:** PVSCSI controllers support units 0-6 and 8-64. Unit 7 is
+reserved for the controller device. LSI Logic, LSI Logic SAS, and BusLogic
+controllers support units 0-6 and 8-15.
+
+The following example creates two new controllers of *different* types.
+`disk_controller_type` entries are consumed in the order distinct new buses
+are first referenced by a `storage` block: `scsi1` is created first, so it
+uses `disk_controller_type[0]` (LSI Logic, unit range 0-6 and 8-15), and
+`scsi2` is created next, so it uses `disk_controller_type[1]` (PVSCSI, unit
+range 0-6 and 8-64). Multiple `storage` blocks that reference the same bus
+share its type without consuming an additional `disk_controller_type` entry:
+
+HCL Example:
+
+```hcl
+disk_controller_type = ["lsilogic", "pvscsi"]
+storage {
+  disk_size            = 10240
+  disk_controller_unit = "scsi1:0"
+}
+storage {
+  disk_size            = 20480
+  disk_controller_unit = "scsi2:0"
+}
+storage {
+  disk_size            = 40960
+  disk_controller_unit = "scsi2:50"
+}
+```
+
+JSON Example:
+
+```json
+"disk_controller_type": ["lsilogic", "pvscsi"],
+"storage": [
+  {
+    "disk_size": 10240,
+    "disk_controller_unit": "scsi1:0"
+  },
+  {
+    "disk_size": 20480,
+    "disk_controller_unit": "scsi2:0"
+  },
+  {
+    "disk_size": 40960,
+    "disk_controller_unit": "scsi2:50"
+  }
+]
+```
+
+`disk_controller_type` entries are consumed in bus-reference order across
+*all* controller kinds combined, not per-kind. The following example creates
+a new SCSI, SATA, and NVMe controller in the same clone: `scsi1` is
+referenced first, so it uses `disk_controller_type[0]` (PVSCSI); `sata0` is
+referenced next, so it uses `disk_controller_type[1]` (SATA); and `nvme0` is
+referenced last, so it uses `disk_controller_type[2]` (NVMe):
+
+HCL Example:
+
+```hcl
+disk_controller_type = ["pvscsi", "sata", "nvme"]
+storage {
+  disk_size            = 10240
+  disk_controller_unit = "scsi1:0"
+}
+storage {
+  disk_size            = 20480
+  disk_controller_unit = "sata0:0"
+}
+storage {
+  disk_size            = 40960
+  disk_controller_unit = "nvme0:0"
+}
+```
+
+JSON Example:
+
+```json
+"disk_controller_type": ["pvscsi", "sata", "nvme"],
+"storage": [
+  {
+    "disk_size": 10240,
+    "disk_controller_unit": "scsi1:0"
+  },
+  {
+    "disk_size": 20480,
+    "disk_controller_unit": "sata0:0"
+  },
+  {
+    "disk_size": 40960,
+    "disk_controller_unit": "nvme0:0"
+  }
+]
+```
+
+~> **Note:** Because the `disk_controller_type` index is assigned by
+reference order rather than by kind, the entry at that index must match the
+kind of the bus being created (SCSI, SATA, or NVMe). For example, referencing
+`nvme0` before `scsi1` while `disk_controller_type` is
+`["lsilogic", "nvme"]` would place `nvme0` at index `0` (`lsilogic`), a
+SCSI-family type. This mismatch is rejected at `packer validate` time.
 
 The following example uses two PVSCSI controllers and two disks on each
 controller:
@@ -396,19 +652,19 @@ HCL Example:
 ```hcl
 disk_controller_type = ["pvscsi", "pvscsi"]
 storage {
-  disk_size             = 15000
+  disk_size             = 10240
   disk_controller_index = 0
 }
 storage {
-  disk_size             = 15000
+  disk_size             = 20480
   disk_controller_index = 0
 }
 storage {
-  disk_size             = 15000
+  disk_size             = 40960
   disk_controller_index = 1
 }
 storage {
-  disk_size             = 15000
+  disk_size             = 81920
   disk_controller_index = 1
 }
 ```
@@ -419,19 +675,19 @@ JSON Example:
 "disk_controller_type": ["pvscsi", "pvscsi"],
 "storage": [
   {
-    "disk_size": 15000,
+    "disk_size": 10240,
     "disk_controller_index": 0
   },
   {
-    "disk_size": 15000,
+    "disk_size": 20480,
     "disk_controller_index": 0
   },
   {
-    "disk_size": 15000,
+    "disk_size": 40960,
     "disk_controller_index": 1
   },
   {
-    "disk_size": 15000,
+    "disk_size": 81920,
     "disk_controller_index": 1
   }
 ]

--- a/.web-docs/components/builder/vsphere-iso/README.md
+++ b/.web-docs/components/builder/vsphere-iso/README.md
@@ -857,6 +857,13 @@ JSON Example:
 
 - `disk_controller_index` (int) - The assigned disk controller for the disk.
   Defaults to the first controller, `(0)`.
+  Mutually exclusive with `disk_controller_unit`.
+
+- `disk_controller_unit` (string) - Explicit controller address for the disk when cloning from a `template`
+  or deploying a VM template `content_library_source`.
+  Format: `{type}{bus}:{unit}` such as `scsi0:1`, `nvme0:0`, or `sata0:2`.
+  Only supported by the `vsphere-clone` builder. Mutually exclusive with
+  `disk_controller_index`.
 
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->
 

--- a/builder/vsphere/clone/builder_acc_test.go
+++ b/builder/vsphere/clone/builder_acc_test.go
@@ -253,6 +253,38 @@ func checkFolderAndResourcePool(d driver.Driver, parent, resourcePool *types.Man
 	return nil
 }
 
+func checkDiskAtControllerUnit(vm driver.VirtualMachine, addr string, wantMiB int64) error {
+	devices, err := vm.Devices()
+	if err != nil {
+		return fmt.Errorf("cannot read devices: %v", err)
+	}
+
+	parsed, err := driver.ParseControllerUnit(addr)
+	if err != nil {
+		return fmt.Errorf("cannot parse controller address %q: %v", addr, err)
+	}
+
+	controller := driver.FindControllerByBus(devices, parsed.Kind, parsed.Bus)
+	if controller == nil {
+		return fmt.Errorf("controller for %q not found on cloned VM", addr)
+	}
+	controllerKey := controller.GetVirtualController().Key
+
+	for _, device := range devices.SelectByType((*types.VirtualDisk)(nil)) {
+		disk := device.(*types.VirtualDisk)
+		vd := disk.GetVirtualDevice()
+		if vd.ControllerKey != controllerKey || vd.UnitNumber == nil || int(*vd.UnitNumber) != parsed.Unit {
+			continue
+		}
+		wantKB := wantMiB * 1024
+		if disk.CapacityInKB != wantKB {
+			return fmt.Errorf("disk at %q: expected %d MiB (%d KB), got %d KB", addr, wantMiB, wantKB, disk.CapacityInKB)
+		}
+		return nil
+	}
+	return fmt.Errorf("no disk found at %q on cloned VM", addr)
+}
+
 func checkOvfSourcePlacement(name string, acc env.AccConfig, mac string) error {
 	d, vm, parent, rp, err := findVM(name)
 	if err != nil {
@@ -442,10 +474,54 @@ func checkMatrixC(name string, acc env.AccConfig) error {
 }
 
 // ---------------------------------------------------------------------------
-// Matrix D — Local OVF Source
+// Matrix D — Explicit Disk Controller Unit
 // ---------------------------------------------------------------------------
 
+// accDiskControllerUnit targets unit 1 on the template's existing primary SCSI
+// controller (scsi0). The template's boot disk is expected to occupy scsi0:0,
+// leaving scsi0:1 free without needing to know the controller's exact type
+// (LSI Logic vs. PVSCSI).
+const accDiskControllerUnit = "scsi0:1"
+
 func TestAccCloneBuilder_MatrixD(t *testing.T) {
+	acceptance.RequireAcceptance(t)
+	config := cloneExampleConfig()
+	vmName := config["vm_name"].(string)
+
+	config["storage"] = map[string]interface{}{
+		"disk_size":            accExtraMiB,
+		"disk_controller_unit": accDiskControllerUnit,
+	}
+
+	testCase := &acctest.PluginTestCase{
+		Name:     "vsphere-clone-matrix-d",
+		Template: acceptance.RenderConfig("vsphere-clone", config),
+		Teardown: func() error {
+			return teardownVM(vmName)
+		},
+		Check: func(buildCommand *exec.Cmd, logfile string) error {
+			if err := checkBuildSucceeded(buildCommand, logfile); err != nil {
+				return err
+			}
+			return checkMatrixD(vmName, accDiskControllerUnit, accExtraMiB)
+		},
+	}
+	acctest.TestPlugin(t, testCase)
+}
+
+func checkMatrixD(name, addr string, wantMiB int64) error {
+	_, vm, _, _, err := findVM(name)
+	if err != nil {
+		return err
+	}
+	return checkDiskAtControllerUnit(vm, addr, wantMiB)
+}
+
+// ---------------------------------------------------------------------------
+// Matrix E — Local OVF Source
+// ---------------------------------------------------------------------------
+
+func TestAccCloneBuilder_MatrixE(t *testing.T) {
 	acceptance.RequireAcceptance(t)
 	acc := env.AccFromEnv()
 	requireOVAURL(t, acc)
@@ -458,7 +534,7 @@ func TestAccCloneBuilder_MatrixD(t *testing.T) {
 	config["ovf_source"] = ovfSourceLocalPath(ovfPath)
 
 	testCase := &acctest.PluginTestCase{
-		Name:     "vsphere-clone-matrix-d",
+		Name:     "vsphere-clone-matrix-e",
 		Template: acceptance.RenderConfig("vsphere-clone", config),
 		Teardown: func() error {
 			return teardownVM(vmName)
@@ -474,10 +550,10 @@ func TestAccCloneBuilder_MatrixD(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Matrix E — Local OVA Source
+// Matrix F — Local OVA Source
 // ---------------------------------------------------------------------------
 
-func TestAccCloneBuilder_MatrixE(t *testing.T) {
+func TestAccCloneBuilder_MatrixF(t *testing.T) {
 	acceptance.RequireAcceptance(t)
 	acc := env.AccFromEnv()
 	requireOVAURL(t, acc)
@@ -490,7 +566,7 @@ func TestAccCloneBuilder_MatrixE(t *testing.T) {
 	config["ovf_source"] = ovfSourceLocalPath(ovaPath)
 
 	testCase := &acctest.PluginTestCase{
-		Name:     "vsphere-clone-matrix-e",
+		Name:     "vsphere-clone-matrix-f",
 		Template: acceptance.RenderConfig("vsphere-clone", config),
 		Teardown: func() error {
 			return teardownVM(vmName)
@@ -506,10 +582,10 @@ func TestAccCloneBuilder_MatrixE(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Matrix F — Remote HTTPS OVF Source
+// Matrix G — Remote HTTPS OVF Source
 // ---------------------------------------------------------------------------
 
-func TestAccCloneBuilder_MatrixF(t *testing.T) {
+func TestAccCloneBuilder_MatrixG(t *testing.T) {
 	acceptance.RequireAcceptance(t)
 	acc := env.AccFromEnv()
 	requireOVFURL(t, acc)
@@ -519,7 +595,7 @@ func TestAccCloneBuilder_MatrixF(t *testing.T) {
 	config["ovf_source"] = ovfSourceRemote(acc, acc.OVFURL)
 
 	testCase := &acctest.PluginTestCase{
-		Name:     "vsphere-clone-matrix-f",
+		Name:     "vsphere-clone-matrix-g",
 		Template: acceptance.RenderConfig("vsphere-clone", config),
 		Teardown: func() error {
 			return teardownVM(vmName)
@@ -535,10 +611,10 @@ func TestAccCloneBuilder_MatrixF(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Matrix G — Remote HTTPS OVA Source
+// Matrix H — Remote HTTPS OVA Source
 // ---------------------------------------------------------------------------
 
-func TestAccCloneBuilder_MatrixG(t *testing.T) {
+func TestAccCloneBuilder_MatrixH(t *testing.T) {
 	acceptance.RequireAcceptance(t)
 	acc := env.AccFromEnv()
 	requireOVAURL(t, acc)
@@ -548,7 +624,7 @@ func TestAccCloneBuilder_MatrixG(t *testing.T) {
 	config["ovf_source"] = ovfSourceRemote(acc, acc.OVAURL)
 
 	testCase := &acctest.PluginTestCase{
-		Name:     "vsphere-clone-matrix-g",
+		Name:     "vsphere-clone-matrix-h",
 		Template: acceptance.RenderConfig("vsphere-clone", config),
 		Teardown: func() error {
 			return teardownVM(vmName)

--- a/builder/vsphere/clone/step_clone.go
+++ b/builder/vsphere/clone/step_clone.go
@@ -255,6 +255,14 @@ func (c *CloneConfig) Prepare() []error {
 
 	errs = append(errs, c.StorageConfig.Prepare()...)
 
+	// disk_controller_unit is validated for both `template` and
+	// `content_library_source` VM templates; a `content_library_source` OVF
+	// template rejects `storage` entirely once the item type is resolved at
+	// deploy time (see validateContentLibrarySourceOptions).
+	if c.Template != "" || c.ContentLibrarySource != nil {
+		errs = append(errs, c.prepareStorage()...)
+	}
+
 	if c.LinkedClone && c.DiskSize != 0 {
 		errs = append(errs, fmt.Errorf("'linked_clone' and 'disk_size' cannot be used together"))
 	}
@@ -386,6 +394,24 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 	}
 }
 
+// disksFromStorageConfig converts the configured storage blocks into driver.Disk
+// values, preserving both the legacy disk_controller_index and explicit
+// disk_controller_unit addressing so callers don't have to duplicate (and risk
+// diverging on) this mapping.
+func disksFromStorageConfig(storage []common.DiskConfig) []driver.Disk {
+	var disks []driver.Disk
+	for _, disk := range storage {
+		disks = append(disks, driver.Disk{
+			DiskSize:            disk.DiskSize,
+			DiskEagerlyScrub:    disk.DiskEagerlyScrub,
+			DiskThinProvisioned: disk.DiskThinProvisioned,
+			ControllerIndex:     disk.DiskControllerIndex,
+			ControllerUnit:      disk.DiskControllerUnit,
+		})
+	}
+	return disks
+}
+
 // cloneFromTemplate handles traditional template-based cloning for backward compatibility.
 func (s *StepCloneVM) cloneFromTemplate(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packersdk.Ui)
@@ -406,14 +432,12 @@ func (s *StepCloneVM) cloneFromTemplate(ctx context.Context, state multistep.Sta
 	}
 
 	ui.Say("Cloning virtual machine...")
-	var disks []driver.Disk
-	for _, disk := range s.Config.StorageConfig.Storage {
-		disks = append(disks, driver.Disk{
-			DiskSize:            disk.DiskSize,
-			DiskEagerlyScrub:    disk.DiskEagerlyScrub,
-			DiskThinProvisioned: disk.DiskThinProvisioned,
-			ControllerIndex:     disk.DiskControllerIndex,
-		})
+	disks := disksFromStorageConfig(s.Config.StorageConfig.Storage)
+
+	templateDevices, err := template.Devices()
+	if err != nil {
+		state.Put("error", fmt.Errorf("error reading template devices: %s", err))
+		return multistep.ActionHalt
 	}
 
 	datastoreName, primaryDatastore := s.resolveDatastore(state)
@@ -425,8 +449,16 @@ func (s *StepCloneVM) cloneFromTemplate(ctx context.Context, state multistep.Sta
 	}
 
 	// Handle multi-disk placement when using a datastore cluster.
+	placementInput := driver.StoragePlacementInput{
+		StorageConfig: driver.StorageConfig{
+			DiskControllerType: s.Config.StorageConfig.DiskControllerType,
+			Storage:            disks,
+		},
+		ExistingDevices: driver.StorageExistingDevices(templateDevices),
+		PrimaryDiskSize: s.Config.DiskSize,
+	}
 	datastoreName, datastoreRefs := common.ResolveMultiDiskDatastoreRefs(
-		ui, d, s.Location.DatastoreCluster, disks, primaryDatastore, datastoreName,
+		ui, d, s.Location.DatastoreCluster, placementInput, primaryDatastore, datastoreName,
 	)
 
 	vm, err := template.Clone(ctx, &driver.CloneConfig{
@@ -494,22 +526,21 @@ func (s *StepCloneVM) deployFromContentLibrary(ctx context.Context, state multis
 		return multistep.ActionHalt
 	}
 
-	var disks []driver.Disk
-	for _, disk := range s.Config.StorageConfig.Storage {
-		disks = append(disks, driver.Disk{
-			DiskSize:            disk.DiskSize,
-			DiskEagerlyScrub:    disk.DiskEagerlyScrub,
-			DiskThinProvisioned: disk.DiskThinProvisioned,
-			ControllerIndex:     disk.DiskControllerIndex,
-		})
-	}
+	disks := disksFromStorageConfig(s.Config.StorageConfig.Storage)
 
 	var datastoreRefs []*types.ManagedObjectReference
 	if item.Type == library.ItemTypeVMTX && s.Location.DatastoreCluster != "" && len(disks) > 1 {
 		if vcDriver, ok := d.(*driver.VCenterDriver); ok {
 			ui.Sayf("Requesting Storage DRS recommendations for %d disks...", len(disks))
 
-			diskDatastores, method, err := vcDriver.SelectDatastoresForDisks(s.Location.DatastoreCluster, disks)
+			placementInput := driver.StoragePlacementInput{
+				StorageConfig: driver.StorageConfig{
+					DiskControllerType: s.Config.StorageConfig.DiskControllerType,
+					Storage:            disks,
+				},
+				PrimaryDiskSize: s.Config.DiskSize,
+			}
+			diskDatastores, method, err := vcDriver.SelectDatastoresForDisks(s.Location.DatastoreCluster, placementInput)
 			if err != nil {
 				ui.Errorf("Warning: Failed to get Storage DRS recommendations: %s. Using primary datastore.", err)
 				if primaryDatastore != nil {

--- a/builder/vsphere/clone/step_clone_test.go
+++ b/builder/vsphere/clone/step_clone_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/mitchellh/mapstructure"
+	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vapi/library"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/packer-plugin-vsphere/builder/vsphere/common"
@@ -36,7 +37,7 @@ func TestCloneConfig_Prepare(t *testing.T) {
 			config: &CloneConfig{
 				Template: "template name",
 				StorageConfig: common.StorageConfig{
-					DiskControllerType: []string{"test"},
+					DiskControllerType: []string{"pvscsi"},
 					Storage: []common.DiskConfig{
 						{
 							DiskSize: 0,
@@ -83,7 +84,7 @@ func TestCloneConfig_Prepare(t *testing.T) {
 			name: "Validate template is set",
 			config: &CloneConfig{
 				StorageConfig: common.StorageConfig{
-					DiskControllerType: []string{"test"},
+					DiskControllerType: []string{"pvscsi"},
 					Storage: []common.DiskConfig{
 						{
 							DiskSize: 32768,
@@ -101,7 +102,7 @@ func TestCloneConfig_Prepare(t *testing.T) {
 				LinkedClone: true,
 				DiskSize:    32768,
 				StorageConfig: common.StorageConfig{
-					DiskControllerType: []string{"test"},
+					DiskControllerType: []string{"pvscsi"},
 					Storage: []common.DiskConfig{
 						{
 							DiskSize: 32768,
@@ -118,7 +119,7 @@ func TestCloneConfig_Prepare(t *testing.T) {
 				Template:   "template name",
 				MacAddress: "some mac address",
 				StorageConfig: common.StorageConfig{
-					DiskControllerType: []string{"test"},
+					DiskControllerType: []string{"pvscsi"},
 					Storage: []common.DiskConfig{
 						{
 							DiskSize: 32768,
@@ -169,7 +170,7 @@ func TestCloneConfig_Prepare(t *testing.T) {
 					URL: "https://packages.example.com/artifacts/example.ovf",
 				},
 				StorageConfig: common.StorageConfig{
-					DiskControllerType: []string{"test"},
+					DiskControllerType: []string{"pvscsi"},
 					Storage: []common.DiskConfig{
 						{
 							DiskSize: 32768,
@@ -245,6 +246,43 @@ func TestCloneConfig_Prepare(t *testing.T) {
 				ContentLibrarySource: &ContentLibrarySourceConfig{
 					Library: "Example Content Library",
 					Name:    "example-template",
+				},
+			},
+			fail: false,
+		},
+		{
+			name: "Validate disk_controller_unit format for content_library_source",
+			config: &CloneConfig{
+				ContentLibrarySource: &ContentLibrarySourceConfig{
+					Library: "Example Content Library",
+					Name:    "example-template",
+				},
+				StorageConfig: common.StorageConfig{
+					Storage: []common.DiskConfig{
+						{
+							DiskSize:           32768,
+							DiskControllerUnit: "not-a-valid-address",
+						},
+					},
+				},
+			},
+			fail:           true,
+			expectedErrMsg: "invalid disk_controller_unit",
+		},
+		{
+			name: "Valid disk_controller_unit for content_library_source",
+			config: &CloneConfig{
+				ContentLibrarySource: &ContentLibrarySourceConfig{
+					Library: "Example Content Library",
+					Name:    "example-template",
+				},
+				StorageConfig: common.StorageConfig{
+					Storage: []common.DiskConfig{
+						{
+							DiskSize:           32768,
+							DiskControllerUnit: "scsi0:1",
+						},
+					},
 				},
 			},
 			fail: false,
@@ -569,6 +607,87 @@ func TestStepCreateVM_Run_nilCloneResult(t *testing.T) {
 	}
 }
 
+func TestStepCloneVM_DatastoreClusterUsesTemplatePlacementInput(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+	state.Put("ui", &packersdk.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	})
+	driverMock := new(clonePlacementDriverMock)
+	state.Put("driver", driverMock)
+	state.Put("datastore", &driver.DatastoreMock{NameReturn: "primary-ds"})
+
+	templateDevices := object.VirtualDeviceList{}
+	controller, err := templateDevices.CreateSCSIController("pvscsi")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	templateDevices = append(templateDevices, controller)
+
+	vmMock := new(driver.VirtualMachineMock)
+	vmMock.DevicesReturn = templateDevices
+	driverMock.VM = vmMock
+
+	ds1 := &driver.DatastoreMock{NameReturn: "drs-ds-1"}
+	ds2 := &driver.DatastoreMock{NameReturn: "drs-ds-2"}
+	driverMock.selectDatastoresForDisksReturn = []driver.Datastore{ds1, ds2}
+	driverMock.selectDatastoresForDisksMethod = driver.SelectionMethodDRS
+
+	location := basicLocationConfig()
+	location.DatastoreCluster = "test-cluster"
+
+	step := &StepCloneVM{
+		Config: &CloneConfig{
+			Template: "template",
+			DiskSize: 8192,
+			StorageConfig: common.StorageConfig{
+				Storage: []common.DiskConfig{
+					{DiskSize: 4096, DiskControllerUnit: "scsi0:1"},
+					{DiskSize: 4096, DiskControllerUnit: "scsi0:2"},
+				},
+			},
+		},
+		Location: location,
+		Force:    true,
+	}
+
+	action := step.Run(context.Background(), state)
+	if action != multistep.ActionContinue {
+		t.Fatalf("expected ActionContinue, got %v; error: %v", action, state.Get("error"))
+	}
+
+	if !driverMock.selectDatastoresForDisksCalled {
+		t.Fatal("expected SelectDatastoresForDisks to be called")
+	}
+	if driverMock.selectDatastoresForDisksInput.PrimaryDiskSize != 8192 {
+		t.Fatalf("expected primary disk resize in placement input, got %d", driverMock.selectDatastoresForDisksInput.PrimaryDiskSize)
+	}
+	if len(driverMock.selectDatastoresForDisksInput.ExistingDevices) == 0 {
+		t.Fatal("expected template devices in placement input")
+	}
+	if !vmMock.CloneCalled {
+		t.Fatal("expected clone to be called")
+	}
+	if len(vmMock.CloneConfig.StorageConfig.DatastoreRefs) != 2 {
+		t.Fatalf("expected 2 per-disk datastore refs, got %d", len(vmMock.CloneConfig.StorageConfig.DatastoreRefs))
+	}
+}
+
+type clonePlacementDriverMock struct {
+	driver.DriverMock
+
+	selectDatastoresForDisksCalled bool
+	selectDatastoresForDisksInput  driver.StoragePlacementInput
+	selectDatastoresForDisksReturn []driver.Datastore
+	selectDatastoresForDisksMethod string
+}
+
+func (m *clonePlacementDriverMock) SelectDatastoresForDisks(clusterName string, input driver.StoragePlacementInput) ([]driver.Datastore, string, error) {
+	m.selectDatastoresForDisksCalled = true
+	m.selectDatastoresForDisksInput = input
+	return m.selectDatastoresForDisksReturn, m.selectDatastoresForDisksMethod, nil
+}
+
 func basicStepCloneVM() *StepCloneVM {
 	step := &StepCloneVM{
 		Config:   createConfig(),
@@ -611,6 +730,7 @@ func driverCreateConfig(config *CloneConfig, location *common.LocationConfig) *d
 			DiskEagerlyScrub:    disk.DiskEagerlyScrub,
 			DiskThinProvisioned: disk.DiskThinProvisioned,
 			ControllerIndex:     disk.DiskControllerIndex,
+			ControllerUnit:      disk.DiskControllerUnit,
 		})
 	}
 
@@ -837,6 +957,61 @@ func TestStepCloneVM_ContentLibraryDeployConfigPassthrough(t *testing.T) {
 	}
 	if cfg.Datastore != "test-datastore" {
 		t.Fatalf("expected datastore %q, got %q", "test-datastore", cfg.Datastore)
+	}
+}
+
+// TestStepCloneVM_ContentLibraryDiskControllerUnitPassthrough guards against a
+// regression where disk_controller_unit was silently dropped when deploying
+// from a content_library_source VM template: the disk would fall back to
+// legacy disk_controller_index placement (index 0) with no error at all.
+func TestStepCloneVM_ContentLibraryDiskControllerUnitPassthrough(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+	state.Put("ui", &packersdk.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	})
+	driverMock := driver.NewDriverMock()
+	driverMock.ResolveContentLibraryItemResult = &library.Item{
+		Name: "example-template",
+		Type: library.ItemTypeVMTX,
+	}
+	driverMock.DeployContentLibraryItemVM = new(driver.VirtualMachineMock)
+	state.Put("driver", driverMock)
+
+	step := &StepCloneVM{
+		Config: &CloneConfig{
+			ContentLibrarySource: &ContentLibrarySourceConfig{
+				Library: "Example Content Library",
+				Name:    "example-template",
+			},
+			StorageConfig: common.StorageConfig{
+				DiskControllerType: []string{"pvscsi"},
+				Storage: []common.DiskConfig{
+					{
+						DiskSize:           32768,
+						DiskControllerUnit: "scsi0:1",
+					},
+				},
+			},
+		},
+		Location: basicLocationConfig(),
+		Force:    true,
+	}
+
+	action := step.Run(context.Background(), state)
+	if action != multistep.ActionContinue {
+		t.Fatalf("expected ActionContinue, got %v; error: %v", action, state.Get("error"))
+	}
+
+	cfg := driverMock.DeployContentLibraryItemConfig
+	if cfg == nil {
+		t.Fatal("expected DeployContentLibraryItemConfig to be set")
+	}
+	if len(cfg.StorageConfig.Storage) != 1 {
+		t.Fatalf("expected 1 storage entry, got %d", len(cfg.StorageConfig.Storage))
+	}
+	if got := cfg.StorageConfig.Storage[0].ControllerUnit; got != "scsi0:1" {
+		t.Fatalf("expected ControllerUnit %q to reach DeployContentLibraryItemConfig, got %q", "scsi0:1", got)
 	}
 }
 

--- a/builder/vsphere/clone/storage_prepare.go
+++ b/builder/vsphere/clone/storage_prepare.go
@@ -1,0 +1,103 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package clone
+
+import (
+	"fmt"
+
+	"github.com/vmware/packer-plugin-vsphere/builder/vsphere/driver"
+)
+
+// busKey identifies a controller bus (e.g. scsi0) referenced by an explicit
+// disk_controller_unit address, independent of the unit portion.
+type busKey struct {
+	kind driver.ControllerKind
+	bus  int
+}
+
+func (c *CloneConfig) prepareStorage() []error {
+	var errs []error
+
+	if len(c.StorageConfig.Storage) == 0 {
+		return errs
+	}
+
+	if err := driver.ValidateDiskControllerTypes(c.StorageConfig.DiskControllerType); err != nil {
+		errs = append(errs, err)
+	}
+
+	hasLegacy := false
+	for _, storage := range c.StorageConfig.Storage {
+		if storage.DiskControllerUnit == "" {
+			hasLegacy = true
+			break
+		}
+	}
+
+	// nextTypeIndex tracks the next unconsumed disk_controller_type entry that
+	// would create a new controller. Legacy storage blocks always create one
+	// controller per disk_controller_type entry, so explicit-unit blocks start
+	// consuming entries after that fixed offset. Multiple explicit-unit blocks
+	// addressing the same bus share a single controller and therefore consume
+	// only one disk_controller_type entry the first time that bus is seen,
+	// mirroring the allocation order used by AddStorageDevices at clone time.
+	//
+	// This is still a best-effort estimate: whether a bus already exists on
+	// the source (the `template`, or the VM deployed from a
+	// `content_library_source` VM template) and thus needs no new controller
+	// at all cannot be known until its devices are read at clone/deploy time,
+	// so controller existence itself remains a runtime-only check (see
+	// ValidateControllerUnitRuntime).
+	nextTypeIndex := 0
+	if hasLegacy {
+		nextTypeIndex = len(c.StorageConfig.DiskControllerType)
+	}
+	busTypeIndex := map[busKey]int{}
+
+	allExplicit := true
+	seenUnits := map[string]int{}
+
+	for i, storage := range c.StorageConfig.Storage {
+		if storage.DiskControllerUnit != "" && storage.DiskControllerIndex != 0 {
+			errs = append(errs, fmt.Errorf("storage[%d]: 'disk_controller_unit' and 'disk_controller_index' are mutually exclusive", i))
+		}
+
+		if storage.DiskControllerUnit != "" {
+			typeIndex := 0
+			if addr, err := driver.ParseControllerUnit(storage.DiskControllerUnit); err == nil {
+				key := busKey{kind: addr.Kind, bus: addr.Bus}
+				if idx, ok := busTypeIndex[key]; ok {
+					typeIndex = idx
+				} else {
+					typeIndex = nextTypeIndex
+					busTypeIndex[key] = typeIndex
+					nextTypeIndex++
+				}
+			}
+
+			if err := driver.ValidateControllerUnitStaticForConfig(
+				storage.DiskControllerUnit,
+				c.StorageConfig.DiskControllerType,
+				typeIndex,
+			); err != nil {
+				errs = append(errs, fmt.Errorf("storage[%d]: %s", i, err))
+			}
+			if prior, ok := seenUnits[storage.DiskControllerUnit]; ok {
+				errs = append(errs, fmt.Errorf("storage[%d]: unit %q is already assigned at storage[%d]. Each unit can only be used once", i, storage.DiskControllerUnit, prior))
+			} else {
+				seenUnits[storage.DiskControllerUnit] = i
+			}
+			continue
+		}
+
+		allExplicit = false
+	}
+
+	if !allExplicit && len(c.StorageConfig.DiskControllerType) == 0 {
+		errs = append(errs, fmt.Errorf("'disk_controller_type' is required when storage blocks use 'disk_controller_index'"))
+	}
+
+	return errs
+}

--- a/builder/vsphere/clone/storage_prepare_test.go
+++ b/builder/vsphere/clone/storage_prepare_test.go
@@ -1,0 +1,241 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package clone
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vmware/packer-plugin-vsphere/builder/vsphere/common"
+)
+
+func TestCloneConfig_prepareStorage(t *testing.T) {
+	testCases := []struct {
+		name           string
+		config         *CloneConfig
+		fail           bool
+		expectedErrMsg string
+	}{
+		{
+			name: "explicit unit without disk_controller_type",
+			config: &CloneConfig{
+				Template: "template",
+				StorageConfig: common.StorageConfig{
+					Storage: []common.DiskConfig{
+						{
+							DiskSize:           4096,
+							DiskControllerUnit: "scsi0:1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "invalid controller type",
+			config: &CloneConfig{
+				Template: "template",
+				StorageConfig: common.StorageConfig{
+					DiskControllerType: []string{"invalid_type"},
+					Storage: []common.DiskConfig{
+						{DiskSize: 4096},
+					},
+				},
+			},
+			fail:           true,
+			expectedErrMsg: "unsupported controller type",
+		},
+		{
+			name: "duplicate disk_controller_unit",
+			config: &CloneConfig{
+				Template: "template",
+				StorageConfig: common.StorageConfig{
+					Storage: []common.DiskConfig{
+						{DiskSize: 4096, DiskControllerUnit: "scsi0:1"},
+						{DiskSize: 4096, DiskControllerUnit: "scsi0:1"},
+					},
+				},
+			},
+			fail:           true,
+			expectedErrMsg: "already assigned",
+		},
+		{
+			name: "mutually exclusive unit and index",
+			config: &CloneConfig{
+				Template: "template",
+				StorageConfig: common.StorageConfig{
+					DiskControllerType: []string{"pvscsi"},
+					Storage: []common.DiskConfig{
+						{
+							DiskSize:            4096,
+							DiskControllerUnit:  "scsi0:1",
+							DiskControllerIndex: 1,
+						},
+					},
+				},
+			},
+			fail:           true,
+			expectedErrMsg: "mutually exclusive",
+		},
+		{
+			name: "legacy path requires disk_controller_type",
+			config: &CloneConfig{
+				Template: "template",
+				StorageConfig: common.StorageConfig{
+					Storage: []common.DiskConfig{
+						{DiskSize: 4096},
+					},
+				},
+			},
+			fail:           true,
+			expectedErrMsg: "'disk_controller_type' is required",
+		},
+		{
+			name: "reserved scsi unit 7",
+			config: &CloneConfig{
+				Template: "template",
+				StorageConfig: common.StorageConfig{
+					Storage: []common.DiskConfig{
+						{DiskSize: 4096, DiskControllerUnit: "scsi0:7"},
+					},
+				},
+			},
+			fail:           true,
+			expectedErrMsg: "unit 7 is reserved",
+		},
+		{
+			name: "pvscsi unit 64 passes prepare",
+			config: &CloneConfig{
+				Template: "template",
+				StorageConfig: common.StorageConfig{
+					DiskControllerType: []string{"pvscsi"},
+					Storage: []common.DiskConfig{
+						{DiskSize: 4096, DiskControllerUnit: "scsi1:64"},
+					},
+				},
+			},
+		},
+		{
+			name: "lsilogic unit 64 fails prepare",
+			config: &CloneConfig{
+				Template: "template",
+				StorageConfig: common.StorageConfig{
+					DiskControllerType: []string{"lsilogic"},
+					Storage: []common.DiskConfig{
+						{DiskSize: 4096, DiskControllerUnit: "scsi1:64"},
+					},
+				},
+			},
+			fail:           true,
+			expectedErrMsg: "unit must be between 0 and 15 for LSI Logic controllers",
+		},
+		{
+			name: "mixed legacy and explicit",
+			config: &CloneConfig{
+				Template: "template",
+				StorageConfig: common.StorageConfig{
+					DiskControllerType: []string{"pvscsi", "pvscsi"},
+					Storage: []common.DiskConfig{
+						{DiskSize: 4096},
+						{DiskSize: 4096, DiskControllerUnit: "scsi0:1"},
+					},
+				},
+			},
+		},
+		{
+			// Regression test: both disks share the controller created for
+			// scsi0 (from diskControllerTypes[0], "pvscsi"), so the second
+			// disk must be validated against PVSCSI's 64-unit limit, not
+			// diskControllerTypes[1] ("lsilogic"). Previously this failed
+			// because Prepare() advanced its type index once per disk instead
+			// of once per distinct new bus.
+			name: "multiple disks on shared new bus use the same controller type",
+			config: &CloneConfig{
+				Template: "template",
+				StorageConfig: common.StorageConfig{
+					DiskControllerType: []string{"pvscsi", "lsilogic"},
+					Storage: []common.DiskConfig{
+						{DiskSize: 4096, DiskControllerUnit: "scsi0:1"},
+						{DiskSize: 4096, DiskControllerUnit: "scsi0:50"},
+					},
+				},
+			},
+		},
+		{
+			// Distinct buses must still consume distinct disk_controller_type
+			// entries in order of first appearance: scsi0 gets "pvscsi" and
+			// scsi1 gets "lsilogic", so unit 20 on scsi1 correctly fails
+			// against LSI Logic's 15-unit limit.
+			name: "distinct new buses map to distinct disk_controller_type entries in order",
+			config: &CloneConfig{
+				Template: "template",
+				StorageConfig: common.StorageConfig{
+					DiskControllerType: []string{"pvscsi", "lsilogic"},
+					Storage: []common.DiskConfig{
+						{DiskSize: 4096, DiskControllerUnit: "scsi0:1"},
+						{DiskSize: 4096, DiskControllerUnit: "scsi1:20"},
+					},
+				},
+			},
+			fail:           true,
+			expectedErrMsg: "unit must be between 0 and 15 for LSI Logic controllers",
+		},
+		{
+			// Regression test: disk_controller_type entries are consumed in
+			// bus-reference order across ALL controller kinds, not per-kind.
+			// nvme0 is referenced first here, so it lands on
+			// diskControllerTypes[0] ("lsilogic"), a SCSI-family type. This
+			// must be rejected at Prepare() time instead of only failing
+			// during Clone() with a low-level controller mismatch error.
+			name: "new bus referenced out of kind order fails prepare",
+			config: &CloneConfig{
+				Template: "template",
+				StorageConfig: common.StorageConfig{
+					DiskControllerType: []string{"lsilogic", "nvme"},
+					Storage: []common.DiskConfig{
+						{DiskSize: 4096, DiskControllerUnit: "nvme0:0"},
+						{DiskSize: 4096, DiskControllerUnit: "scsi1:0"},
+					},
+				},
+			},
+			fail:           true,
+			expectedErrMsg: `disk_controller_type[0] is "lsilogic"`,
+		},
+		{
+			// Correctly ordered mixed-kind config: scsi1 is referenced
+			// first (index 0, "pvscsi"), sata0 next (index 1, "sata"), and
+			// nvme0 last (index 2, "nvme").
+			name: "mixed controller kinds referenced in matching order pass prepare",
+			config: &CloneConfig{
+				Template: "template",
+				StorageConfig: common.StorageConfig{
+					DiskControllerType: []string{"pvscsi", "sata", "nvme"},
+					Storage: []common.DiskConfig{
+						{DiskSize: 4096, DiskControllerUnit: "scsi1:0"},
+						{DiskSize: 4096, DiskControllerUnit: "sata0:0"},
+						{DiskSize: 4096, DiskControllerUnit: "nvme0:0"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := tc.config.prepareStorage()
+			if tc.fail {
+				if len(errs) == 0 {
+					t.Fatal("expected failure")
+				}
+				if tc.expectedErrMsg != "" && !strings.Contains(errs[0].Error(), tc.expectedErrMsg) {
+					t.Fatalf("expected error containing %q, got %q", tc.expectedErrMsg, errs[0].Error())
+				}
+				return
+			}
+			if len(errs) != 0 {
+				t.Fatalf("unexpected error: %s", errs[0])
+			}
+		})
+	}
+}

--- a/builder/vsphere/common/step_resolve_datastore.go
+++ b/builder/vsphere/common/step_resolve_datastore.go
@@ -99,13 +99,13 @@ func ResolveMultiDiskDatastoreRefs(
 	ui packersdk.Ui,
 	d driver.Driver,
 	datastoreCluster string,
-	disks []driver.Disk,
+	input driver.StoragePlacementInput,
 	primaryDatastore driver.Datastore,
 	datastoreName string,
 ) (string, []*types.ManagedObjectReference) {
 	// Single-disk and zero-disk cases rely on StepResolveDatastore; per-disk refs
 	// are only needed when multiple additional disks may land on different datastores.
-	if datastoreCluster == "" || len(disks) <= 1 {
+	if datastoreCluster == "" || len(input.StorageConfig.Storage) <= 1 {
 		return datastoreName, nil
 	}
 
@@ -114,17 +114,17 @@ func ResolveMultiDiskDatastoreRefs(
 		return datastoreName, nil
 	}
 
-	ui.Sayf("Requesting Storage DRS recommendations for %d disks...", len(disks))
+	ui.Sayf("Requesting Storage DRS recommendations for %d disks...", len(input.StorageConfig.Storage))
 
-	diskDatastores, method, err := dsSelector.SelectDatastoresForDisks(datastoreCluster, disks)
+	diskDatastores, method, err := dsSelector.SelectDatastoresForDisks(datastoreCluster, input)
 	if err != nil {
 		ui.Sayf("Warning: Failed to get Storage DRS recommendations: %s. Using primary datastore.", err)
 		if primaryDatastore == nil {
 			return datastoreName, nil
 		}
 
-		datastoreRefs := make([]*types.ManagedObjectReference, 0, len(disks))
-		for i := 0; i < len(disks); i++ {
+		datastoreRefs := make([]*types.ManagedObjectReference, 0, len(input.StorageConfig.Storage))
+		for i := 0; i < len(input.StorageConfig.Storage); i++ {
 			ref := primaryDatastore.Reference()
 			datastoreRefs = append(datastoreRefs, &ref)
 		}

--- a/builder/vsphere/common/step_resolve_datastore_test.go
+++ b/builder/vsphere/common/step_resolve_datastore_test.go
@@ -5,12 +5,14 @@
 package common
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/vmware/packer-plugin-vsphere/builder/vsphere/driver"
 )
 
@@ -167,6 +169,67 @@ func TestStepResolveDatastore_Cleanup(t *testing.T) {
 	step.Cleanup(state)
 }
 
+func TestResolveMultiDiskDatastoreRefs(t *testing.T) {
+	ui := &packersdk.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	}
+
+	mock := NewVCenterDriverMock()
+	ds1 := &driver.DatastoreMock{NameReturn: "datastore-1"}
+	ds2 := &driver.DatastoreMock{NameReturn: "datastore-2"}
+	mock.SelectDatastoresForDisksReturn = []driver.Datastore{ds1, ds2}
+	mock.SelectDatastoresForDisksMethod = driver.SelectionMethodDRS
+
+	input := driver.StoragePlacementInput{
+		StorageConfig: driver.StorageConfig{
+			DiskControllerType: []string{"pvscsi"},
+			Storage: []driver.Disk{
+				{DiskSize: 4096, ControllerUnit: "scsi0:1"},
+				{DiskSize: 8192, ControllerUnit: "scsi0:2"},
+			},
+		},
+	}
+
+	datastoreName, refs := ResolveMultiDiskDatastoreRefs(
+		ui, mock, "test-cluster", input, ds1, "initial-datastore",
+	)
+
+	if !mock.SelectDatastoresForDisksCalled {
+		t.Fatal("expected SelectDatastoresForDisks to be called")
+	}
+	if len(mock.SelectDatastoresForDisksInput.StorageConfig.Storage) != 2 {
+		t.Fatalf("expected placement input with 2 disks, got %d", len(mock.SelectDatastoresForDisksInput.StorageConfig.Storage))
+	}
+	if datastoreName != "datastore-1" {
+		t.Fatalf("unexpected datastore name: %q", datastoreName)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 datastore refs, got %d", len(refs))
+	}
+}
+
+func TestResolveMultiDiskDatastoreRefsSkipsSingleDisk(t *testing.T) {
+	mock := NewVCenterDriverMock()
+	input := driver.StoragePlacementInput{
+		StorageConfig: driver.StorageConfig{
+			Storage: []driver.Disk{{DiskSize: 4096}},
+		},
+	}
+
+	_, refs := ResolveMultiDiskDatastoreRefs(
+		&packersdk.BasicUi{Reader: new(bytes.Buffer), Writer: new(bytes.Buffer)},
+		mock, "test-cluster", input, nil, "initial-datastore",
+	)
+
+	if mock.SelectDatastoresForDisksCalled {
+		t.Fatal("expected SelectDatastoresForDisks not to be called for single disk")
+	}
+	if refs != nil {
+		t.Fatal("expected nil datastore refs for single disk")
+	}
+}
+
 // VCenterDriverMock embeds DriverMock and adds VCenterDriver-specific methods for testing
 type VCenterDriverMock struct {
 	*driver.DriverMock
@@ -175,6 +238,12 @@ type VCenterDriverMock struct {
 	SelectDatastoreReturn driver.Datastore
 	SelectDatastoreMethod string
 	SelectDatastoreErr    error
+
+	SelectDatastoresForDisksCalled bool
+	SelectDatastoresForDisksInput  driver.StoragePlacementInput
+	SelectDatastoresForDisksReturn []driver.Datastore
+	SelectDatastoresForDisksMethod string
+	SelectDatastoresForDisksErr    error
 }
 
 // NewVCenterDriverMock creates a new VCenterDriverMock
@@ -188,4 +257,14 @@ func NewVCenterDriverMock() *VCenterDriverMock {
 func (d *VCenterDriverMock) SelectDatastoreFromCluster(clusterName string) (driver.Datastore, string, error) {
 	d.SelectDatastoreCalled = true
 	return d.SelectDatastoreReturn, d.SelectDatastoreMethod, d.SelectDatastoreErr
+}
+
+// SelectDatastoresForDisks mocks multi-disk Storage DRS placement.
+func (d *VCenterDriverMock) SelectDatastoresForDisks(clusterName string, input driver.StoragePlacementInput) ([]driver.Datastore, string, error) {
+	d.SelectDatastoresForDisksCalled = true
+	d.SelectDatastoresForDisksInput = input
+	if d.SelectDatastoresForDisksErr != nil {
+		return nil, "", d.SelectDatastoresForDisksErr
+	}
+	return d.SelectDatastoresForDisksReturn, d.SelectDatastoresForDisksMethod, nil
 }

--- a/builder/vsphere/common/storage_config.go
+++ b/builder/vsphere/common/storage_config.go
@@ -22,7 +22,14 @@ type DiskConfig struct {
 	DiskEagerlyScrub bool `mapstructure:"disk_eagerly_scrub"`
 	// The assigned disk controller for the disk.
 	// Defaults to the first controller, `(0)`.
+	// Mutually exclusive with `disk_controller_unit`.
 	DiskControllerIndex int `mapstructure:"disk_controller_index"`
+	// Explicit controller address for the disk when cloning from a `template`
+	// or deploying a VM template `content_library_source`.
+	// Format: `{type}{bus}:{unit}` such as `scsi0:1`, `nvme0:0`, or `sata0:2`.
+	// Only supported by the `vsphere-clone` builder. Mutually exclusive with
+	// `disk_controller_index`.
+	DiskControllerUnit string `mapstructure:"disk_controller_unit"`
 }
 
 // Disk layout depends on the builder and clone source. For `vsphere-clone`,
@@ -57,7 +64,7 @@ func (c *StorageConfig) Prepare() []error {
 			if storage.DiskSize == 0 {
 				errs = append(errs, fmt.Errorf("storage[%d].'disk_size' is required", i))
 			}
-			if storage.DiskControllerIndex >= len(c.DiskControllerType) {
+			if storage.DiskControllerUnit == "" && storage.DiskControllerIndex >= len(c.DiskControllerType) {
 				errs = append(errs, fmt.Errorf("storage[%d].'disk_controller_index' references an unknown disk controller", i))
 			}
 		}

--- a/builder/vsphere/common/storage_config.hcl2spec.go
+++ b/builder/vsphere/common/storage_config.hcl2spec.go
@@ -10,10 +10,11 @@ import (
 // FlatDiskConfig is an auto-generated flat version of DiskConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatDiskConfig struct {
-	DiskSize            *int64 `mapstructure:"disk_size" required:"true" cty:"disk_size" hcl:"disk_size"`
-	DiskThinProvisioned *bool  `mapstructure:"disk_thin_provisioned" cty:"disk_thin_provisioned" hcl:"disk_thin_provisioned"`
-	DiskEagerlyScrub    *bool  `mapstructure:"disk_eagerly_scrub" cty:"disk_eagerly_scrub" hcl:"disk_eagerly_scrub"`
-	DiskControllerIndex *int   `mapstructure:"disk_controller_index" cty:"disk_controller_index" hcl:"disk_controller_index"`
+	DiskSize            *int64  `mapstructure:"disk_size" required:"true" cty:"disk_size" hcl:"disk_size"`
+	DiskThinProvisioned *bool   `mapstructure:"disk_thin_provisioned" cty:"disk_thin_provisioned" hcl:"disk_thin_provisioned"`
+	DiskEagerlyScrub    *bool   `mapstructure:"disk_eagerly_scrub" cty:"disk_eagerly_scrub" hcl:"disk_eagerly_scrub"`
+	DiskControllerIndex *int    `mapstructure:"disk_controller_index" cty:"disk_controller_index" hcl:"disk_controller_index"`
+	DiskControllerUnit  *string `mapstructure:"disk_controller_unit" cty:"disk_controller_unit" hcl:"disk_controller_unit"`
 }
 
 // FlatMapstructure returns a new FlatDiskConfig.
@@ -32,6 +33,7 @@ func (*FlatDiskConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disk_thin_provisioned": &hcldec.AttrSpec{Name: "disk_thin_provisioned", Type: cty.Bool, Required: false},
 		"disk_eagerly_scrub":    &hcldec.AttrSpec{Name: "disk_eagerly_scrub", Type: cty.Bool, Required: false},
 		"disk_controller_index": &hcldec.AttrSpec{Name: "disk_controller_index", Type: cty.Number, Required: false},
+		"disk_controller_unit":  &hcldec.AttrSpec{Name: "disk_controller_unit", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/vsphere/driver/controller_address.go
+++ b/builder/vsphere/driver/controller_address.go
@@ -1,0 +1,651 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package driver
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+const (
+	maxControllersPerType  = 4
+	maxControllerBusNumber = 3
+
+	// SCSI unit and disk limits (vSphere 8+).
+	scsiReservedUnitNumber       = 7
+	maxLSISCSIUnit               = 15
+	maxPVSCSIUnit                = 64
+	maxLSISCSIDisksPerController = 15
+	maxPVSCSIDisksPerController  = 64
+
+	// NVMe and SATA unit and disk limits.
+	maxNVMeUnit               = 14
+	maxSATAUnit               = 29
+	maxNVMEDisksPerController = maxNVMeUnit + 1
+	maxSATADisksPerController = maxSATAUnit + 1
+
+	maxSCSIDisksPerVM    = 256
+	maxLSISCSIDisksPerVM = 60
+	maxSATADisksPerVM    = 120
+	maxNVMEDisksPerVM    = 60
+
+	controllerTypeLSILogic    = "lsilogic"
+	controllerTypeLSILogicSAS = "lsilogic-sas"
+	controllerTypePVSCSI      = "pvscsi"
+	controllerTypeNVMe        = "nvme"
+	controllerTypeSCSI        = "scsi"
+	controllerTypeSATA        = "sata"
+)
+
+var controllerTypeDisplayNames = map[string]string{
+	controllerTypeLSILogic:    "LSI Logic",
+	controllerTypeLSILogicSAS: "LSI Logic SAS",
+	controllerTypePVSCSI:      "PVSCSI",
+	controllerTypeNVMe:        "NVMe",
+	controllerTypeSATA:        "SATA",
+}
+
+var controllerUnitPattern = regexp.MustCompile(`^(scsi|nvme|sata)([0-3]):([0-9]+)$`)
+
+// SupportedDiskControllerTypes lists valid disk_controller_type values.
+var SupportedDiskControllerTypes = map[string]struct{}{
+	controllerTypeLSILogic:    {},
+	controllerTypeLSILogicSAS: {},
+	controllerTypePVSCSI:      {},
+	controllerTypeNVMe:        {},
+	controllerTypeSCSI:        {},
+	controllerTypeSATA:        {},
+}
+
+// ControllerKind identifies a storage controller bus family.
+type ControllerKind int
+
+const (
+	ControllerKindSCSI ControllerKind = iota
+	ControllerKindNVMe
+	ControllerKindSATA
+)
+
+// ControllerAddress is a parsed controller:unit address (e.g. scsi0:1).
+type ControllerAddress struct {
+	Kind ControllerKind
+	Bus  int
+	Unit int
+}
+
+func (a ControllerAddress) String() string {
+	return fmt.Sprintf("%s%d:%d", controllerKindPrefix(a.Kind), a.Bus, a.Unit)
+}
+
+func controllerKindPrefix(kind ControllerKind) string {
+	switch kind {
+	case ControllerKindNVMe:
+		return "nvme"
+	case ControllerKindSATA:
+		return "sata"
+	default:
+		return "scsi"
+	}
+}
+
+// ParseControllerUnit parses an address such as "scsi0:1" or "nvme0:0".
+func ParseControllerUnit(raw string) (ControllerAddress, error) {
+	matches := controllerUnitPattern.FindStringSubmatch(strings.TrimSpace(raw))
+	if matches == nil {
+		return ControllerAddress{}, fmt.Errorf("invalid disk_controller_unit %q: expected format scsi0:1, nvme0:0, or sata0:2", raw)
+	}
+
+	bus, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return ControllerAddress{}, fmt.Errorf("invalid disk_controller_unit %q: bus number must be 0-3", raw)
+	}
+
+	unit, err := strconv.Atoi(matches[3])
+	if err != nil {
+		return ControllerAddress{}, fmt.Errorf("invalid disk_controller_unit %q: unit must be a non-negative integer", raw)
+	}
+
+	var kind ControllerKind
+	switch matches[1] {
+	case "scsi":
+		kind = ControllerKindSCSI
+	case "nvme":
+		kind = ControllerKindNVMe
+	case "sata":
+		kind = ControllerKindSATA
+	}
+
+	return ControllerAddress{Kind: kind, Bus: bus, Unit: unit}, nil
+}
+
+// ValidateControllerUnitStatic validates address format and static vSphere limits.
+func ValidateControllerUnitStatic(raw string) error {
+	return ValidateControllerUnitStaticForConfig(raw, nil, 0)
+}
+
+// ValidateControllerUnitStaticForConfig validates unit limits using disk_controller_type hints.
+// typeIndex is the effective disk_controller_type index that would create the controller for
+// this address's bus if it does not already exist on the template. Callers are responsible for
+// resolving typeIndex so that multiple addresses sharing the same bus map to the same index,
+// matching the runtime allocator in AddStorageDevices.
+func ValidateControllerUnitStaticForConfig(raw string, diskControllerTypes []string, typeIndex int) error {
+	addr, err := ParseControllerUnit(raw)
+	if err != nil {
+		return err
+	}
+
+	if addr.Bus < 0 || addr.Bus > maxControllerBusNumber {
+		return fmt.Errorf("invalid disk_controller_unit %q: bus number must be 0-%d", raw, maxControllerBusNumber)
+	}
+
+	if addr.Kind == ControllerKindSCSI && addr.Unit == scsiReservedUnitNumber {
+		return fmt.Errorf("unit %d is reserved for the SCSI controller on %q", scsiReservedUnitNumber, raw)
+	}
+
+	// disk_controller_type entries are consumed in the order distinct new
+	// buses are first referenced, across all controller kinds (SCSI, SATA,
+	// and NVMe share one index sequence). If the entry landing on this
+	// address's index is the wrong family for its bus kind, AddStorageDevices
+	// will still refuse to create the mismatched controller at clone time,
+	// but with a low-level error. Catch the ordering mistake here instead,
+	// where it can be reported clearly and before any resources are touched.
+	if typeIndex < len(diskControllerTypes) {
+		if entryKind := controllerKindForType(diskControllerTypes[typeIndex]); entryKind != addr.Kind {
+			return fmt.Errorf(
+				"disk_controller_unit %q would create a new %s%d controller, but disk_controller_type[%d] is %q (%s). "+
+					"disk_controller_type entries are consumed in the order distinct new buses are first referenced across storage blocks, "+
+					"regardless of controller kind: reorder disk_controller_type so index %d holds a %s controller type, or reorder the storage blocks",
+				raw, controllerKindPrefix(addr.Kind), addr.Bus, typeIndex, diskControllerTypes[typeIndex],
+				displayNameForControllerType(diskControllerTypes[typeIndex]), typeIndex, strings.ToUpper(controllerKindPrefix(addr.Kind)),
+			)
+		}
+	}
+
+	maxUnit := staticMaxUnitForAddress(addr, diskControllerTypes, typeIndex)
+	if addr.Unit < 0 || addr.Unit > maxUnit {
+		displayName := staticDisplayNameForAddress(addr, diskControllerTypes, typeIndex)
+		return fmt.Errorf("invalid disk_controller_unit %q: unit must be between 0 and %d for %s controllers", raw, maxUnit, displayName)
+	}
+
+	return nil
+}
+
+func staticDisplayNameForAddress(addr ControllerAddress, diskControllerTypes []string, typeIndex int) string {
+	switch addr.Kind {
+	case ControllerKindNVMe:
+		return displayNameForControllerType(controllerTypeNVMe)
+	case ControllerKindSATA:
+		return displayNameForControllerType(controllerTypeSATA)
+	default:
+		if typeIndex < len(diskControllerTypes) {
+			return displayNameForControllerType(diskControllerTypes[typeIndex])
+		}
+		if containsPVSCSIType(diskControllerTypes) {
+			return displayNameForControllerType(controllerTypePVSCSI)
+		}
+		return "SCSI"
+	}
+}
+
+func staticMaxUnitForAddress(addr ControllerAddress, diskControllerTypes []string, typeIndex int) int {
+	if typeIndex < len(diskControllerTypes) {
+		return maxUnitForControllerTypeString(diskControllerTypes[typeIndex], addr.Kind)
+	}
+
+	if addr.Kind == ControllerKindSCSI && containsPVSCSIType(diskControllerTypes) {
+		return maxPVSCSIUnit
+	}
+
+	maxUnit, _ := maxUnitForKind(addr.Kind, nil)
+	return maxUnit
+}
+
+func containsPVSCSIType(diskControllerTypes []string) bool {
+	for _, controllerType := range diskControllerTypes {
+		if controllerType == controllerTypePVSCSI {
+			return true
+		}
+	}
+	return false
+}
+
+func maxUnitForControllerTypeString(controllerType string, kind ControllerKind) int {
+	switch kind {
+	case ControllerKindNVMe:
+		return maxNVMeUnit
+	case ControllerKindSATA:
+		return maxSATAUnit
+	default:
+		if controllerType == controllerTypePVSCSI {
+			return maxPVSCSIUnit
+		}
+		return maxLSISCSIUnit
+	}
+}
+
+func maxUnitForKind(kind ControllerKind, controller types.BaseVirtualController) (int, error) {
+	switch kind {
+	case ControllerKindSCSI:
+		if _, ok := controller.(types.BaseVirtualSCSIController); ok && isPVSCSIController(controller) {
+			return maxPVSCSIUnit, nil
+		}
+		return maxLSISCSIUnit, nil
+	case ControllerKindNVMe:
+		return maxNVMeUnit, nil
+	case ControllerKindSATA:
+		return maxSATAUnit, nil
+	default:
+		return 0, fmt.Errorf("unknown controller kind")
+	}
+}
+
+func maxDisksPerController(controller types.BaseVirtualController) int {
+	maxUnit, err := maxUnitForKind(controllerKindForController(controller), controller)
+	if err != nil {
+		return 0
+	}
+	if _, ok := controller.(types.BaseVirtualSCSIController); ok {
+		if maxUnit == maxPVSCSIUnit {
+			return maxPVSCSIDisksPerController
+		}
+		return maxLSISCSIDisksPerController
+	}
+	return maxUnit + 1
+}
+
+func controllerKindForController(controller types.BaseVirtualController) ControllerKind {
+	kind, _, ok := controllerBusNumber(controller)
+	if !ok {
+		return ControllerKindSCSI
+	}
+	return kind
+}
+
+// displayNameForControllerType returns a user-facing label for a disk_controller_type value.
+func displayNameForControllerType(controllerType string) string {
+	if name, ok := controllerTypeDisplayNames[controllerType]; ok {
+		return name
+	}
+	return "SCSI"
+}
+
+// controllerDisplayName returns a user-facing label for a runtime controller device.
+func controllerDisplayName(controller types.BaseVirtualController) string {
+	if isPVSCSIController(controller) {
+		return "PVSCSI"
+	}
+	switch controller.(type) {
+	case *types.VirtualLsiLogicSASController:
+		return "LSI Logic SAS"
+	case *types.VirtualLsiLogicController:
+		return "LSI Logic"
+	case *types.VirtualBusLogicController:
+		return "BusLogic"
+	case *types.VirtualNVMEController:
+		return "NVMe"
+	case types.BaseVirtualSATAController:
+		return "SATA"
+	default:
+		return "SCSI"
+	}
+}
+
+func isPVSCSIController(controller types.BaseVirtualController) bool {
+	switch controller.(type) {
+	case *types.ParaVirtualSCSIController:
+		return true
+	default:
+		return false
+	}
+}
+
+func controllerBusNumber(controller types.BaseVirtualController) (ControllerKind, int, bool) {
+	switch c := controller.(type) {
+	case types.BaseVirtualSCSIController:
+		return ControllerKindSCSI, int(c.GetVirtualSCSIController().BusNumber), true
+	case *types.VirtualNVMEController:
+		return ControllerKindNVMe, int(c.BusNumber), true
+	case types.BaseVirtualSATAController:
+		return ControllerKindSATA, int(c.GetVirtualSATAController().BusNumber), true
+	default:
+		return 0, 0, false
+	}
+}
+
+func controllerAddressLabel(controller types.BaseVirtualController) string {
+	kind, bus, ok := controllerBusNumber(controller)
+	if !ok {
+		return "unknown"
+	}
+	return fmt.Sprintf("%s%d", controllerKindPrefix(kind), bus)
+}
+
+// FindControllerByBus returns the controller matching kind and bus number.
+func FindControllerByBus(devices object.VirtualDeviceList, kind ControllerKind, bus int) types.BaseVirtualController {
+	for _, device := range devices {
+		controller, ok := device.(types.BaseVirtualController)
+		if !ok {
+			continue
+		}
+		k, b, ok := controllerBusNumber(controller)
+		if ok && k == kind && b == bus {
+			return controller
+		}
+	}
+	return nil
+}
+
+// ListControllerAddresses returns sorted controller addresses present in devices.
+func ListControllerAddresses(devices object.VirtualDeviceList) []string {
+	var addrs []string
+	for _, device := range devices {
+		controller, ok := device.(types.BaseVirtualController)
+		if !ok {
+			continue
+		}
+		addrs = append(addrs, controllerAddressLabel(controller))
+	}
+	sort.Strings(addrs)
+	return addrs
+}
+
+// OccupiedUnits returns unit numbers in use on a controller, including reserved units.
+func OccupiedUnits(devices object.VirtualDeviceList, controller types.BaseVirtualController) map[int]bool {
+	occupied := map[int]bool{}
+	key := controller.GetVirtualController().Key
+
+	if sc, ok := controller.(types.BaseVirtualSCSIController); ok {
+		occupied[int(sc.GetVirtualSCSIController().ScsiCtlrUnitNumber)] = true
+	}
+
+	for _, device := range devices {
+		d := device.GetVirtualDevice()
+		if d.ControllerKey != key || d.UnitNumber == nil {
+			continue
+		}
+		occupied[int(*d.UnitNumber)] = true
+	}
+
+	return occupied
+}
+
+func listAvailableUnits(devices object.VirtualDeviceList, controller types.BaseVirtualController) []int {
+	maxUnit, err := maxUnitForKind(controllerKindForController(controller), controller)
+	if err != nil {
+		return nil
+	}
+
+	occupied := OccupiedUnits(devices, controller)
+	var available []int
+	for unit := 0; unit <= maxUnit; unit++ {
+		if _, ok := controller.(types.BaseVirtualSCSIController); ok && unit == scsiReservedUnitNumber {
+			continue
+		}
+		if !occupied[unit] {
+			available = append(available, unit)
+		}
+	}
+	return available
+}
+
+func formatAvailableUnits(units []int) string {
+	if len(units) == 0 {
+		return "none"
+	}
+
+	var ranges []string
+	start := units[0]
+	prev := units[0]
+
+	for i := 1; i < len(units); i++ {
+		if units[i] == prev+1 {
+			prev = units[i]
+			continue
+		}
+		ranges = append(ranges, formatUnitRange(start, prev))
+		start = units[i]
+		prev = units[i]
+	}
+	ranges = append(ranges, formatUnitRange(start, prev))
+	return strings.Join(ranges, ", ")
+}
+
+func formatUnitRange(start, end int) string {
+	if start == end {
+		return strconv.Itoa(start)
+	}
+	return fmt.Sprintf("%d-%d", start, end)
+}
+
+func countDisksOnController(devices object.VirtualDeviceList, controller types.BaseVirtualController) int {
+	key := controller.GetVirtualController().Key
+	count := 0
+	for _, device := range devices {
+		d := device.GetVirtualDevice()
+		if _, ok := device.(*types.VirtualDisk); !ok {
+			continue
+		}
+		if d.ControllerKey == key {
+			count++
+		}
+	}
+	return count
+}
+
+func scsiDiskUnitRange(maxUnit int) string {
+	return fmt.Sprintf("units 0-6, 8-%d; unit %d reserved", maxUnit, scsiReservedUnitNumber)
+}
+
+func validateControllerDiskCapacity(devices object.VirtualDeviceList, controller types.BaseVirtualController, adding int) error {
+	current := countDisksOnController(devices, controller)
+	requested := current + adding
+	maxDisks := maxDisksPerController(controller)
+
+	if requested <= maxDisks {
+		return nil
+	}
+
+	label := controllerAddressLabel(controller)
+	name := controllerDisplayName(controller)
+	if isPVSCSIController(controller) {
+		return fmt.Errorf("%s controller %s supports maximum %d disks (%s). Requested: %d disks",
+			name, label, maxPVSCSIDisksPerController, scsiDiskUnitRange(maxPVSCSIUnit), requested)
+	}
+	if _, ok := controller.(types.BaseVirtualSCSIController); ok {
+		return fmt.Errorf("%s controller %s supports maximum %d disks (%s). Requested: %d disks",
+			name, label, maxLSISCSIDisksPerController, scsiDiskUnitRange(maxLSISCSIUnit), requested)
+	}
+	return fmt.Errorf("%s controller %s supports maximum %d disks. Requested: %d disks", name, label, maxDisks, requested)
+}
+
+func countVirtualDisksByKind(devices object.VirtualDeviceList) map[ControllerKind]int {
+	counts := map[ControllerKind]int{}
+	for _, device := range devices {
+		if _, ok := device.(*types.VirtualDisk); !ok {
+			continue
+		}
+		controllerKey := device.GetVirtualDevice().ControllerKey
+		for _, controllerDevice := range devices {
+			controller, ok := controllerDevice.(types.BaseVirtualController)
+			if !ok {
+				continue
+			}
+			if controller.GetVirtualController().Key != controllerKey {
+				continue
+			}
+			kind, _, ok := controllerBusNumber(controller)
+			if ok {
+				counts[kind]++
+			}
+			break
+		}
+	}
+	return counts
+}
+
+func hasPVSCSIControllerOnVM(devices object.VirtualDeviceList) bool {
+	for _, device := range devices {
+		controller, ok := device.(types.BaseVirtualController)
+		if !ok {
+			continue
+		}
+		if isPVSCSIController(controller) {
+			return true
+		}
+	}
+	return false
+}
+
+func validateAggregateStorageCapacity(devices object.VirtualDeviceList) error {
+	counts := countVirtualDisksByKind(devices)
+
+	if counts[ControllerKindSATA] > maxSATADisksPerVM {
+		return fmt.Errorf("virtual machine supports maximum %d SATA disks. Requested: %d disks", maxSATADisksPerVM, counts[ControllerKindSATA])
+	}
+	if counts[ControllerKindNVMe] > maxNVMEDisksPerVM {
+		return fmt.Errorf("virtual machine supports maximum %d NVMe disks. Requested: %d disks", maxNVMEDisksPerVM, counts[ControllerKindNVMe])
+	}
+
+	scsiMax := maxLSISCSIDisksPerVM
+	if hasPVSCSIControllerOnVM(devices) {
+		scsiMax = maxSCSIDisksPerVM
+	}
+	if counts[ControllerKindSCSI] > scsiMax {
+		if scsiMax == maxSCSIDisksPerVM {
+			return fmt.Errorf("virtual machine supports maximum %d SCSI disks with PVSCSI controllers. Requested: %d disks", maxSCSIDisksPerVM, counts[ControllerKindSCSI])
+		}
+		return fmt.Errorf("virtual machine supports maximum %d SCSI disks. Requested: %d disks", maxLSISCSIDisksPerVM, counts[ControllerKindSCSI])
+	}
+
+	return nil
+}
+
+// ValidateControllerUnitRuntime checks unit availability on an existing controller at clone time.
+func ValidateControllerUnitRuntime(devices object.VirtualDeviceList, raw string, pending map[string]struct{}) error {
+	addr, err := ParseControllerUnit(raw)
+	if err != nil {
+		return err
+	}
+
+	if pending != nil {
+		if _, exists := pending[raw]; exists {
+			return fmt.Errorf("unit %q is already assigned. Each unit can only be used once", raw)
+		}
+	}
+
+	controller := FindControllerByBus(devices, addr.Kind, addr.Bus)
+	if controller == nil {
+		return nil
+	}
+
+	maxUnit, err := maxUnitForKind(addr.Kind, controller)
+	if err != nil {
+		return err
+	}
+	if addr.Unit > maxUnit {
+		return fmt.Errorf("invalid disk_controller_unit %q: unit exceeds maximum %d for this controller type", raw, maxUnit)
+	}
+
+	if OccupiedUnits(devices, controller)[addr.Unit] {
+		available := formatAvailableUnits(listAvailableUnits(devices, controller))
+		return fmt.Errorf("unit %q is already in use. Available units: %s", addr.String(), available)
+	}
+
+	return nil
+}
+
+// ValidateDiskControllerTypes returns an error if any type is unsupported.
+func ValidateDiskControllerTypes(types []string) error {
+	for i, controllerType := range types {
+		if _, ok := SupportedDiskControllerTypes[controllerType]; !ok {
+			return fmt.Errorf("unsupported controller type %q at disk_controller_type[%d]. Supported types: lsilogic, lsilogic-sas, pvscsi, nvme, scsi, sata", controllerType, i)
+		}
+	}
+	return nil
+}
+
+func controllerKindForType(controllerType string) ControllerKind {
+	switch controllerType {
+	case controllerTypeNVMe:
+		return ControllerKindNVMe
+	case controllerTypeSATA:
+		return ControllerKindSATA
+	default:
+		return ControllerKindSCSI
+	}
+}
+
+func countControllersByKind(devices object.VirtualDeviceList) map[ControllerKind]int {
+	counts := map[ControllerKind]int{}
+	for _, device := range devices {
+		controller, ok := device.(types.BaseVirtualController)
+		if !ok {
+			continue
+		}
+		kind, _, ok := controllerBusNumber(controller)
+		if ok {
+			counts[kind]++
+		}
+	}
+	return counts
+}
+
+func validateControllerCount(devices object.VirtualDeviceList, kind ControllerKind, adding int) error {
+	counts := countControllersByKind(devices)
+	if counts[kind]+adding > maxControllersPerType {
+		return fmt.Errorf("maximum of %d %s controllers allowed per virtual machine", maxControllersPerType, controllerKindPrefix(kind))
+	}
+	return nil
+}
+
+func createController(devices object.VirtualDeviceList, controllerType string) (types.BaseVirtualDevice, error) {
+	switch controllerType {
+	case controllerTypeNVMe:
+		return devices.CreateNVMEController()
+	case controllerTypeSATA:
+		return devices.CreateSATAController()
+	default:
+		return devices.CreateSCSIController(controllerType)
+	}
+}
+
+func assignDiskAtUnit(devices object.VirtualDeviceList, disk *types.VirtualDisk, controller types.BaseVirtualController, unit int32, linkController bool) {
+	d := disk.GetVirtualDevice()
+	d.ControllerKey = controller.GetVirtualController().Key
+	d.UnitNumber = &unit
+	if d.Key == 0 {
+		d.Key = devices.NewKey()
+	}
+	if linkController {
+		controller.GetVirtualController().Device = append(controller.GetVirtualController().Device, d.Key)
+	}
+}
+
+func controllerNotFoundError(raw string, available []string) error {
+	addr, err := ParseControllerUnit(raw)
+	if err != nil {
+		return err
+	}
+	controllerLabel := fmt.Sprintf("%s%d", controllerKindPrefix(addr.Kind), addr.Bus)
+	if len(available) == 0 {
+		return fmt.Errorf("controller %q not found: no storage controllers on template", controllerLabel)
+	}
+	return fmt.Errorf("controller %q not found. Available controllers: %s", controllerLabel, strings.Join(available, ", "))
+}
+
+func typePoolExhaustedError(raw string) error {
+	addr, err := ParseControllerUnit(raw)
+	if err != nil {
+		return err
+	}
+	controllerLabel := fmt.Sprintf("%s%d", controllerKindPrefix(addr.Kind), addr.Bus)
+	return fmt.Errorf("no disk_controller_type entries remain to create controller %q. Add an entry to disk_controller_type or reference an existing controller", controllerLabel)
+}

--- a/builder/vsphere/driver/controller_address_test.go
+++ b/builder/vsphere/driver/controller_address_test.go
@@ -1,0 +1,351 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package driver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestParseControllerUnit(t *testing.T) {
+	testCases := []struct {
+		name    string
+		input   string
+		want    ControllerAddress
+		wantErr bool
+	}{
+		{
+			name:  "scsi",
+			input: "scsi0:1",
+			want:  ControllerAddress{Kind: ControllerKindSCSI, Bus: 0, Unit: 1},
+		},
+		{
+			name:  "nvme",
+			input: "nvme1:0",
+			want:  ControllerAddress{Kind: ControllerKindNVMe, Bus: 1, Unit: 0},
+		},
+		{
+			name:  "sata",
+			input: "sata2:29",
+			want:  ControllerAddress{Kind: ControllerKindSATA, Bus: 2, Unit: 29},
+		},
+		{
+			name:    "invalid format",
+			input:   "scsi0-1",
+			wantErr: true,
+		},
+		{
+			name:    "invalid bus",
+			input:   "scsi9:0",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseControllerUnit(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if got != tc.want {
+				t.Fatalf("unexpected result: expected %#v, got %#v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestValidateControllerUnitStatic(t *testing.T) {
+	testCases := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{name: "valid pvscsi unit", input: "scsi1:8"},
+		{name: "valid nvme unit", input: "nvme0:14"},
+		{name: "reserved scsi unit 7", input: "scsi0:7", wantErr: "unit 7 is reserved"},
+		{name: "scsi unit too high", input: "scsi0:16", wantErr: "unit must be between 0 and 15 for SCSI controllers"},
+		{name: "nvme unit too high", input: "nvme0:15", wantErr: "unit must be between 0 and 14 for NVMe controllers"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateControllerUnitStatic(tc.input)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateControllerUnitStaticForConfig(t *testing.T) {
+	testCases := []struct {
+		name                string
+		input               string
+		diskControllerTypes []string
+		typeIndex           int
+		wantErr             string
+	}{
+		{
+			name:                "pvscsi unit 64 with pvscsi type",
+			input:               "scsi1:64",
+			diskControllerTypes: []string{"pvscsi"},
+			wantErr:             "",
+		},
+		{
+			name:                "pvscsi unit 64 with lsilogic type",
+			input:               "scsi1:64",
+			diskControllerTypes: []string{"lsilogic"},
+			wantErr:             "unit must be between 0 and 15 for LSI Logic controllers",
+		},
+		{
+			name:                "explicit on-demand pvscsi after legacy",
+			input:               "scsi2:32",
+			diskControllerTypes: []string{"pvscsi", "pvscsi", "pvscsi"},
+			// All three disk_controller_type entries are consumed by legacy
+			// storage blocks, so this address falls past the end of the list
+			// and is validated against the PVSCSI fallback.
+			typeIndex: 3,
+			wantErr:   "",
+		},
+		{
+			name:                "second disk on same new bus uses same type as first",
+			input:               "scsi0:50",
+			diskControllerTypes: []string{"pvscsi", "lsilogic"},
+			// Both disks addressing scsi0 share the controller created from
+			// diskControllerTypes[0] ("pvscsi"), so the second disk must also
+			// be validated against PVSCSI's limits, not diskControllerTypes[1].
+			typeIndex: 0,
+			wantErr:   "",
+		},
+		{
+			name:                "nvme address mapped to a scsi type entry",
+			input:               "nvme0:0",
+			diskControllerTypes: []string{"lsilogic", "nvme"},
+			// nvme0 is referenced before scsi1 in this hypothetical config,
+			// so it lands on index 0 ("lsilogic"), a SCSI-family type. That
+			// mismatch must be reported clearly instead of silently
+			// validating nvme0 against NVMe limits and letting it fail at
+			// clone time with a low-level bus mismatch error.
+			typeIndex: 0,
+			wantErr:   `disk_controller_type[0] is "lsilogic"`,
+		},
+		{
+			name:                "sata address mapped to an nvme type entry",
+			input:               "sata0:0",
+			diskControllerTypes: []string{"nvme"},
+			typeIndex:           0,
+			wantErr:             `disk_controller_type[0] is "nvme"`,
+		},
+		{
+			name:                "scsi address mapped to a sata type entry",
+			input:               "scsi1:0",
+			diskControllerTypes: []string{"sata"},
+			typeIndex:           0,
+			wantErr:             `disk_controller_type[0] is "sata"`,
+		},
+		{
+			name:                "correctly ordered mixed kinds",
+			input:               "nvme0:0",
+			diskControllerTypes: []string{"pvscsi", "sata", "nvme"},
+			typeIndex:           2,
+			wantErr:             "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateControllerUnitStaticForConfig(tc.input, tc.diskControllerTypes, tc.typeIndex)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestListAvailableUnits(t *testing.T) {
+	devices := object.VirtualDeviceList{}
+	controller, err := devices.CreateSCSIController("lsilogic")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	devices = append(devices, controller)
+
+	controllerObj, err := devices.FindDiskController(devices.Name(controller))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	disk := &types.VirtualDisk{
+		VirtualDevice: types.VirtualDevice{
+			Key: devices.NewKey(),
+		},
+		CapacityInKB: 1024,
+	}
+	assignDiskAtUnit(devices, disk, controllerObj, 1, true)
+	devices = append(devices, disk)
+
+	available := listAvailableUnits(devices, controllerObj)
+	if len(available) == 0 {
+		t.Fatal("expected available units")
+	}
+	for _, unit := range available {
+		if unit == 1 {
+			t.Fatal("unit 1 should be occupied")
+		}
+		if unit == 7 {
+			t.Fatal("unit 7 should be reserved for SCSI")
+		}
+	}
+}
+
+func TestValidateStorageCapacity(t *testing.T) {
+	devices := object.VirtualDeviceList{}
+	controller, err := devices.CreateSCSIController("lsilogic")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	devices = append(devices, controller)
+
+	controllerObj, err := devices.FindDiskController(devices.Name(controller))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	for unit := 0; unit <= 15; unit++ {
+		if unit == 7 {
+			continue
+		}
+		disk := &types.VirtualDisk{
+			VirtualDevice: types.VirtualDevice{
+				Key: devices.NewKey(),
+			},
+			CapacityInKB: 1024,
+		}
+		assignDiskAtUnit(devices, disk, controllerObj, int32(unit), true)
+		devices = append(devices, disk)
+	}
+
+	err = validateControllerDiskCapacity(devices, controllerObj, 1)
+	if err == nil || !strings.Contains(err.Error(), "supports maximum 15 disks") {
+		t.Fatalf("expected capacity error, got %v", err)
+	}
+}
+
+func TestControllerDisplayName(t *testing.T) {
+	testCases := []struct {
+		controllerType string
+		want           string
+	}{
+		{controllerType: controllerTypePVSCSI, want: "PVSCSI"},
+		{controllerType: controllerTypeLSILogic, want: "LSI Logic"},
+		{controllerType: controllerTypeLSILogicSAS, want: "LSI Logic SAS"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.controllerType, func(t *testing.T) {
+			devices := object.VirtualDeviceList{}
+			controller, err := devices.CreateSCSIController(tc.controllerType)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			devices = append(devices, controller)
+
+			controllerObj, err := devices.FindDiskController(devices.Name(controller))
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if got := controllerDisplayName(controllerObj); got != tc.want {
+				t.Fatalf("unexpected display name: expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestDisplayNameForControllerType(t *testing.T) {
+	testCases := []struct {
+		controllerType string
+		want           string
+	}{
+		{controllerType: controllerTypePVSCSI, want: "PVSCSI"},
+		{controllerType: controllerTypeLSILogic, want: "LSI Logic"},
+		{controllerType: controllerTypeSCSI, want: "SCSI"},
+		{controllerType: "unknown", want: "SCSI"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.controllerType, func(t *testing.T) {
+			if got := displayNameForControllerType(tc.controllerType); got != tc.want {
+				t.Fatalf("unexpected display name: expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestFindControllerByBus(t *testing.T) {
+	devices := object.VirtualDeviceList{}
+	controller, err := devices.CreateSCSIController("pvscsi")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	devices = append(devices, controller)
+
+	found := FindControllerByBus(devices, ControllerKindSCSI, 0)
+	if found == nil {
+		t.Fatal("expected to find scsi0 controller")
+	}
+
+	if FindControllerByBus(devices, ControllerKindSCSI, 1) != nil {
+		t.Fatal("expected scsi1 controller to be missing")
+	}
+}
+
+func TestValidateControllerUnitRuntimeOccupied(t *testing.T) {
+	devices := object.VirtualDeviceList{}
+	controller, err := devices.CreateSCSIController("pvscsi")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	devices = append(devices, controller)
+
+	controllerObj, err := devices.FindDiskController(devices.Name(controller))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	disk := &types.VirtualDisk{
+		VirtualDevice: types.VirtualDevice{
+			Key: devices.NewKey(),
+		},
+		CapacityInKB: 1024,
+	}
+	assignDiskAtUnit(devices, disk, controllerObj, 1, true)
+	devices = append(devices, disk)
+
+	err = ValidateControllerUnitRuntime(devices, "scsi0:1", nil)
+	if err == nil || !strings.Contains(err.Error(), "already in use") || !strings.Contains(err.Error(), "Available units:") {
+		t.Fatalf("expected occupied unit error with available units, got %v", err)
+	}
+}

--- a/builder/vsphere/driver/disk.go
+++ b/builder/vsphere/driver/disk.go
@@ -6,6 +6,7 @@ package driver
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
@@ -16,6 +17,7 @@ type Disk struct {
 	DiskEagerlyScrub    bool
 	DiskThinProvisioned bool
 	ControllerIndex     int
+	ControllerUnit      string
 }
 
 type StorageConfig struct {
@@ -25,61 +27,167 @@ type StorageConfig struct {
 }
 
 // AddStorageDevices adds virtual storage devices to an existing device list.
-// It creates a controller for each type specified in DiskControllerType and attaches
-// virtual disks to the controllers. If DatastoreRefs is provided, each disk is placed
-// on the corresponding datastore; otherwise, disks inherit the VM's datastore.
+// Disks with ControllerUnit attach at explicit addresses; disks without use
+// disk_controller_index against newly created controllers from DiskControllerType.
 func (c *StorageConfig) AddStorageDevices(existingDevices object.VirtualDeviceList) ([]types.BaseVirtualDeviceConfigSpec, error) {
-	newDevices := object.VirtualDeviceList{}
+	return c.addStorageDevices(existingDevices, storageAttachOptions{linkControllerDevices: true, validateAggregate: true})
+}
 
-	var controllers []types.BaseVirtualController
-	for _, controllerType := range c.DiskControllerType {
-		var device types.BaseVirtualDevice
-		var err error
-		switch controllerType {
-		case "nvme":
-			device, err = existingDevices.CreateNVMEController()
-		case "sata":
-			device, err = existingDevices.CreateSATAController()
-		default:
-			device, err = existingDevices.CreateSCSIController(controllerType)
-		}
-		if err != nil {
-			return nil, err
-		}
-		existingDevices = append(existingDevices, device)
-		newDevices = append(newDevices, device)
-		controller, err := existingDevices.FindDiskController(existingDevices.Name(device))
-		if err != nil {
-			return nil, err
-		}
-		controllers = append(controllers, controller)
+// AddStorageDevicesForPlacement builds device config specs without mutating shared
+// template controller state. Used for Storage DRS placement requests only.
+func (c *StorageConfig) AddStorageDevicesForPlacement(existingDevices object.VirtualDeviceList) ([]types.BaseVirtualDeviceConfigSpec, error) {
+	devices := append(object.VirtualDeviceList{}, existingDevices...)
+	return c.addStorageDevices(devices, storageAttachOptions{linkControllerDevices: false, validateAggregate: false})
+}
+
+type storageAttachOptions struct {
+	linkControllerDevices bool
+	validateAggregate     bool
+}
+
+func (c *StorageConfig) addStorageDevices(existingDevices object.VirtualDeviceList, opts storageAttachOptions) ([]types.BaseVirtualDeviceConfigSpec, error) {
+	if len(c.Storage) == 0 {
+		return nil, nil
 	}
 
-	for i, dc := range c.Storage {
-		backing := &types.VirtualDiskFlatVer2BackingInfo{
-			DiskMode:        string(types.VirtualDiskModePersistent),
-			ThinProvisioned: types.NewBool(dc.DiskThinProvisioned),
-			EagerlyScrub:    types.NewBool(dc.DiskEagerlyScrub),
+	newDevices := object.VirtualDeviceList{}
+	typeIndex := 0
+
+	var legacyDisks []int
+	var explicitDisks []int
+	for i, disk := range c.Storage {
+		if disk.ControllerUnit != "" {
+			explicitDisks = append(explicitDisks, i)
+		} else {
+			legacyDisks = append(legacyDisks, i)
+		}
+	}
+
+	var legacyControllers []types.BaseVirtualController
+	if len(legacyDisks) > 0 {
+		for _, controllerType := range c.DiskControllerType {
+			device, err := createController(existingDevices, controllerType)
+			if err != nil {
+				return nil, err
+			}
+			kind := controllerKindForType(controllerType)
+			if err := validateControllerCount(existingDevices, kind, 1); err != nil {
+				return nil, err
+			}
+
+			existingDevices = append(existingDevices, device)
+			newDevices = append(newDevices, device)
+
+			controller, err := existingDevices.FindDiskController(existingDevices.Name(device))
+			if err != nil {
+				return nil, err
+			}
+			legacyControllers = append(legacyControllers, controller)
 		}
 
-		if i < len(c.DatastoreRefs) && c.DatastoreRefs[i] != nil {
-			backing.Datastore = c.DatastoreRefs[i]
+		for _, i := range legacyDisks {
+			disk := c.buildDisk(existingDevices, c.Storage[i], i)
+			if c.Storage[i].ControllerIndex >= len(legacyControllers) {
+				return nil, fmt.Errorf("storage[%d].'disk_controller_index' references an unknown disk controller", i)
+			}
+			controller := legacyControllers[c.Storage[i].ControllerIndex]
+			if err := validateControllerDiskCapacity(existingDevices, controller, 1); err != nil {
+				return nil, fmt.Errorf("storage[%d]: %s", i, err)
+			}
+			existingDevices.AssignController(disk, controller)
+			existingDevices = append(existingDevices, disk)
+			newDevices = append(newDevices, disk)
 		}
 
-		disk := &types.VirtualDisk{
-			VirtualDevice: types.VirtualDevice{
-				Key:     existingDevices.NewKey(),
-				Backing: backing,
-			},
-			CapacityInKB: dc.DiskSize * 1024,
+		typeIndex = len(c.DiskControllerType)
+	}
+
+	pendingUnits := map[string]struct{}{}
+	for _, i := range explicitDisks {
+		raw := c.Storage[i].ControllerUnit
+		if err := ValidateControllerUnitRuntime(existingDevices, raw, pendingUnits); err != nil {
+			return nil, fmt.Errorf("storage[%d]: %s", i, err)
 		}
 
-		existingDevices.AssignController(disk, controllers[dc.ControllerIndex])
+		addr, err := ParseControllerUnit(raw)
+		if err != nil {
+			return nil, fmt.Errorf("storage[%d]: %s", i, err)
+		}
+
+		controller := FindControllerByBus(existingDevices, addr.Kind, addr.Bus)
+		if controller == nil {
+			if typeIndex >= len(c.DiskControllerType) {
+				available := ListControllerAddresses(existingDevices)
+				if len(available) == 0 {
+					return nil, fmt.Errorf("storage[%d]: %s", i, typePoolExhaustedError(raw))
+				}
+				return nil, fmt.Errorf("storage[%d]: %s", i, controllerNotFoundError(raw, available))
+			}
+
+			controllerType := c.DiskControllerType[typeIndex]
+			typeIndex++
+
+			device, err := createController(existingDevices, controllerType)
+			if err != nil {
+				return nil, fmt.Errorf("storage[%d]: %s", i, err)
+			}
+			kind := controllerKindForType(controllerType)
+			if err := validateControllerCount(existingDevices, kind, 1); err != nil {
+				return nil, fmt.Errorf("storage[%d]: %s", i, err)
+			}
+
+			existingDevices = append(existingDevices, device)
+			newDevices = append(newDevices, device)
+
+			controller, err = existingDevices.FindDiskController(existingDevices.Name(device))
+			if err != nil {
+				return nil, fmt.Errorf("storage[%d]: %s", i, err)
+			}
+
+			k, bus, ok := controllerBusNumber(controller)
+			if !ok || k != addr.Kind || bus != addr.Bus {
+				return nil, fmt.Errorf("storage[%d]: created controller bus does not match %q", i, raw)
+			}
+		}
+
+		if err := validateControllerDiskCapacity(existingDevices, controller, 1); err != nil {
+			return nil, fmt.Errorf("storage[%d]: %s", i, err)
+		}
+
+		disk := c.buildDisk(existingDevices, c.Storage[i], i)
+		assignDiskAtUnit(existingDevices, disk, controller, int32(addr.Unit), opts.linkControllerDevices)
 		existingDevices = append(existingDevices, disk)
 		newDevices = append(newDevices, disk)
+		pendingUnits[raw] = struct{}{}
+	}
+
+	if opts.validateAggregate {
+		if err := validateAggregateStorageCapacity(existingDevices); err != nil {
+			return nil, err
+		}
 	}
 
 	return newDevices.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
+}
+
+func (c *StorageConfig) buildDisk(devices object.VirtualDeviceList, dc Disk, index int) *types.VirtualDisk {
+	backing := &types.VirtualDiskFlatVer2BackingInfo{
+		DiskMode:        string(types.VirtualDiskModePersistent),
+		ThinProvisioned: types.NewBool(dc.DiskThinProvisioned),
+		EagerlyScrub:    types.NewBool(dc.DiskEagerlyScrub),
+	}
+
+	if index < len(c.DatastoreRefs) && c.DatastoreRefs[index] != nil {
+		backing.Datastore = c.DatastoreRefs[index]
+	}
+
+	return &types.VirtualDisk{
+		VirtualDevice: types.VirtualDevice{
+			Key:     devices.NewKey(),
+			Backing: backing,
+		},
+		CapacityInKB: dc.DiskSize * 1024,
+	}
 }
 
 // findDisk scans a list of virtual devices and retrieves a single virtual disk.

--- a/builder/vsphere/driver/disk_test.go
+++ b/builder/vsphere/driver/disk_test.go
@@ -5,9 +5,11 @@
 package driver
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 func TestAddStorageDevices(t *testing.T) {
@@ -49,5 +51,214 @@ func TestAddStorageDevices(t *testing.T) {
 	}
 	if len(storageConfigSpec) != 3 {
 		t.Fatalf("unexpected result: expected '3', but returned '%d'", len(storageConfigSpec))
+	}
+}
+
+func TestAddStorageDevicesExplicitUnit(t *testing.T) {
+	existingDevices := object.VirtualDeviceList{}
+	controller, err := existingDevices.CreateSCSIController("pvscsi")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	existingDevices = append(existingDevices, controller)
+
+	disk := &types.VirtualDisk{
+		VirtualDevice: types.VirtualDevice{
+			Key: existingDevices.NewKey(),
+		},
+		CapacityInKB: 1024,
+	}
+	controllerObj, err := existingDevices.FindDiskController(existingDevices.Name(controller))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	assignDiskAtUnit(existingDevices, disk, controllerObj, 0, true)
+	existingDevices = append(existingDevices, disk)
+
+	config := &StorageConfig{
+		Storage: []Disk{
+			{
+				DiskSize:       4096,
+				ControllerUnit: "scsi0:1",
+			},
+		},
+	}
+
+	storageConfigSpec, err := config.AddStorageDevices(existingDevices)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(storageConfigSpec) != 1 {
+		t.Fatalf("unexpected result: expected '1', but returned '%d'", len(storageConfigSpec))
+	}
+
+	added := storageConfigSpec[0].GetVirtualDeviceConfigSpec().Device.(*types.VirtualDisk)
+	if added.UnitNumber == nil || *added.UnitNumber != 1 {
+		t.Fatalf("unexpected unit number: expected 1, got %#v", added.UnitNumber)
+	}
+}
+
+func TestAddStorageDevicesExplicitUnitNewController(t *testing.T) {
+	existingDevices := object.VirtualDeviceList{}
+	controller, err := existingDevices.CreateSCSIController("pvscsi")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	existingDevices = append(existingDevices, controller)
+
+	config := &StorageConfig{
+		DiskControllerType: []string{"pvscsi"},
+		Storage: []Disk{
+			{
+				DiskSize:       4096,
+				ControllerUnit: "scsi1:0",
+			},
+		},
+	}
+
+	storageConfigSpec, err := config.AddStorageDevices(existingDevices)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(storageConfigSpec) != 2 {
+		t.Fatalf("unexpected result: expected '2', but returned '%d'", len(storageConfigSpec))
+	}
+
+	var added *types.VirtualDisk
+	for _, spec := range storageConfigSpec {
+		disk, ok := spec.GetVirtualDeviceConfigSpec().Device.(*types.VirtualDisk)
+		if !ok {
+			continue
+		}
+		if disk.UnitNumber != nil && *disk.UnitNumber == 0 {
+			added = disk
+			break
+		}
+	}
+	if added == nil {
+		t.Fatal("expected disk at scsi1:0")
+	}
+}
+
+func TestAddStorageDevicesMixedLegacyAndExplicit(t *testing.T) {
+	existingDevices := object.VirtualDeviceList{}
+	controller, err := existingDevices.CreateSCSIController("pvscsi")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	existingDevices = append(existingDevices, controller)
+
+	config := &StorageConfig{
+		DiskControllerType: []string{"pvscsi", "pvscsi"},
+		Storage: []Disk{
+			{
+				DiskSize:        2048,
+				ControllerIndex: 0,
+			},
+			{
+				DiskSize:       4096,
+				ControllerUnit: "scsi2:0",
+			},
+		},
+	}
+
+	storageConfigSpec, err := config.AddStorageDevices(existingDevices)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(storageConfigSpec) != 4 {
+		t.Fatalf("unexpected result: expected '4', but returned '%d'", len(storageConfigSpec))
+	}
+
+	devices := append(object.VirtualDeviceList{}, existingDevices...)
+	for _, spec := range storageConfigSpec {
+		devices = append(devices, spec.GetVirtualDeviceConfigSpec().Device)
+	}
+
+	if FindControllerByBus(devices, ControllerKindSCSI, 2) == nil {
+		t.Fatal("expected scsi2 controller from on-demand creation")
+	}
+}
+
+func TestAddStorageDevicesMixedControllerKinds(t *testing.T) {
+	existingDevices := object.VirtualDeviceList{}
+	// Templates always have at least one existing SCSI controller (scsi0);
+	// without it, a brand-new SCSI controller would be assigned bus 0, not
+	// bus 1, so "scsi1:0" below would not match.
+	controller, err := existingDevices.CreateSCSIController("pvscsi")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	existingDevices = append(existingDevices, controller)
+
+	config := &StorageConfig{
+		DiskControllerType: []string{"pvscsi", "sata", "nvme"},
+		Storage: []Disk{
+			{DiskSize: 2048, ControllerUnit: "scsi1:0"},
+			{DiskSize: 2048, ControllerUnit: "sata0:0"},
+			{DiskSize: 2048, ControllerUnit: "nvme0:0"},
+		},
+	}
+
+	storageConfigSpec, err := config.AddStorageDevices(existingDevices)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	devices := append(object.VirtualDeviceList{}, existingDevices...)
+	for _, spec := range storageConfigSpec {
+		devices = append(devices, spec.GetVirtualDeviceConfigSpec().Device)
+	}
+
+	if len(storageConfigSpec) != 6 {
+		t.Fatalf("unexpected result: expected '6' (3 controllers + 3 disks), but returned '%d'", len(storageConfigSpec))
+	}
+	if FindControllerByBus(devices, ControllerKindSCSI, 1) == nil {
+		t.Fatal("expected scsi1 controller from on-demand creation")
+	}
+	if FindControllerByBus(devices, ControllerKindSATA, 0) == nil {
+		t.Fatal("expected sata0 controller from on-demand creation")
+	}
+	if FindControllerByBus(devices, ControllerKindNVMe, 0) == nil {
+		t.Fatal("expected nvme0 controller from on-demand creation")
+	}
+}
+
+func TestAddStorageDevicesMismatchedControllerKindOrder(t *testing.T) {
+	existingDevices := object.VirtualDeviceList{}
+
+	// scsi0 is referenced first but disk_controller_type[0] is "nvme": the
+	// type-index allocator is purely order-based across ALL controller
+	// kinds, not per-kind, so this must fail rather than silently create an
+	// NVMe controller for what the caller addressed as scsi0.
+	config := &StorageConfig{
+		DiskControllerType: []string{"nvme", "pvscsi"},
+		Storage: []Disk{
+			{DiskSize: 2048, ControllerUnit: "scsi0:0"},
+			{DiskSize: 2048, ControllerUnit: "nvme0:0"},
+		},
+	}
+
+	_, err := config.AddStorageDevices(existingDevices)
+	if err == nil || !strings.Contains(err.Error(), "created controller bus does not match") {
+		t.Fatalf("expected a controller bus mismatch error, got %v", err)
+	}
+}
+
+func TestAddStorageDevicesTypePoolExhausted(t *testing.T) {
+	existingDevices := object.VirtualDeviceList{}
+
+	config := &StorageConfig{
+		Storage: []Disk{
+			{
+				DiskSize:       4096,
+				ControllerUnit: "scsi0:0",
+			},
+		},
+	}
+
+	_, err := config.AddStorageDevices(existingDevices)
+	if err == nil || !strings.Contains(err.Error(), "no disk_controller_type entries remain") {
+		t.Fatalf("expected type pool exhausted error, got %v", err)
 	}
 }

--- a/builder/vsphere/driver/driver.go
+++ b/builder/vsphere/driver/driver.go
@@ -61,7 +61,7 @@ type Driver interface {
 // DatastoreSelector is an optional driver capability for multi-disk datastore
 // placement from a datastore cluster.
 type DatastoreSelector interface {
-	SelectDatastoresForDisks(clusterName string, disks []Disk) ([]Datastore, string, error)
+	SelectDatastoresForDisks(clusterName string, input StoragePlacementInput) ([]Datastore, string, error)
 }
 
 // VCenterDriver implements the Driver interface for vCenter operations.

--- a/builder/vsphere/driver/driver_mock.go
+++ b/builder/vsphere/driver/driver_mock.go
@@ -268,3 +268,8 @@ func (d *DriverMock) DeployContentLibraryItem(ctx context.Context, config *Conte
 func (d *DriverMock) Cleanup() (error, error) {
 	return nil, nil
 }
+
+// SelectDatastoresForDisks mocks multi-disk Storage DRS placement for testing.
+func (d *DriverMock) SelectDatastoresForDisks(clusterName string, input StoragePlacementInput) ([]Datastore, string, error) {
+	return nil, "", fmt.Errorf("SelectDatastoresForDisks not implemented in DriverMock")
+}

--- a/builder/vsphere/driver/storage_drs.go
+++ b/builder/vsphere/driver/storage_drs.go
@@ -69,13 +69,11 @@ func (d *VCenterDriver) RequestStoragePlacement(
 	return &res.Returnval, nil
 }
 
-// SelectDatastoresForDisks requests Storage DRS recommendations for multiple
-// disks at once. This allows Storage DRS to make optimal placement decisions.
-// Returns a slice of datastores (one per disk), selection method, and any
-// error.
+// SelectDatastoresForDisks requests Storage DRS recommendations using the same
+// storage device topology that clone and create apply at runtime.
 func (d *VCenterDriver) SelectDatastoresForDisks(
 	clusterName string,
-	disks []Disk,
+	input StoragePlacementInput,
 ) ([]Datastore, string, error) {
 	cluster, err := d.FindDatastoreCluster(clusterName)
 	if err != nil {
@@ -91,8 +89,17 @@ func (d *VCenterDriver) SelectDatastoresForDisks(
 		return nil, "", fmt.Errorf("datastore cluster '%s' contains no available datastores", clusterName)
 	}
 
-	// Create a virtual machine spec with multiple disks for Storage DRS to
-	// evaluate for placement.
+	fallback := datastores[0]
+	diskCount := len(input.StorageConfig.Storage)
+	if diskCount == 0 {
+		return nil, "", fmt.Errorf("no disks provided for storage placement")
+	}
+
+	deviceChanges, newDiskKeys, err := BuildStoragePlacementConfigSpec(input)
+	if err != nil {
+		return nil, "", err
+	}
+
 	vmSpec := types.VirtualMachineConfigSpec{
 		Name:     fmt.Sprintf("packer-placement-request-%d", time.Now().UnixNano()),
 		NumCPUs:  1,
@@ -100,106 +107,159 @@ func (d *VCenterDriver) SelectDatastoresForDisks(
 		Files: &types.VirtualMachineFileInfo{
 			VmPathName: fmt.Sprintf("[%s]", clusterName),
 		},
+		DeviceChange: deviceChanges,
 	}
 
-	// Add disk device specs to the virtual machine config using actual disk
-	// configurations.
-	deviceList := object.VirtualDeviceList{}
-	controller, err := deviceList.CreateSCSIController("pvscsi")
-	if err != nil {
-		return nil, "", fmt.Errorf("error creating controller for DRS request: %s", err)
-	}
-	deviceList = append(deviceList, controller)
-
-	for i, diskConfig := range disks {
-		disk := &types.VirtualDisk{
-			VirtualDevice: types.VirtualDevice{
-				Key: int32(-100 - i),
-				Backing: &types.VirtualDiskFlatVer2BackingInfo{
-					DiskMode:        string(types.VirtualDiskModePersistent),
-					ThinProvisioned: types.NewBool(diskConfig.DiskThinProvisioned),
-					EagerlyScrub:    types.NewBool(diskConfig.DiskEagerlyScrub),
-				},
-			},
-			CapacityInKB: diskConfig.DiskSize * 1024,
-		}
-		deviceList.AssignController(disk, controller.(types.BaseVirtualController))
-		deviceList = append(deviceList, disk)
-	}
-
-	deviceSpecs, err := deviceList.ConfigSpec(types.VirtualDeviceConfigSpecOperationAdd)
-	if err != nil {
-		return nil, "", fmt.Errorf("error creating device specs for DRS request: %s", err)
-	}
-	vmSpec.DeviceChange = deviceSpecs
-
-	// Get resource pool for the Storage DRS request.
-	var resourcePoolRef *types.ManagedObjectReference
-	if len(datastores) > 0 {
-		dsInfo, err := datastores[0].Info("host")
-		if err == nil && len(dsInfo.Host) > 0 {
-			hostRef := dsInfo.Host[0].Key
-			host := object.NewHostSystem(d.Client.Client, hostRef)
-			hostInfo, err := host.ResourcePool(d.Ctx)
-			if err == nil {
-				ref := hostInfo.Reference()
-				resourcePoolRef = &ref
-			}
-		}
-	}
+	resourcePoolRef := resourcePoolFromDatastores(d, datastores)
 
 	placementResult, err := d.RequestStoragePlacement(cluster.Reference(), vmSpec, resourcePoolRef)
 	if err == nil && placementResult != nil && len(placementResult.Recommendations) > 0 {
 		recommendation := placementResult.Recommendations[0]
+		if diskDatastores, ok := d.datastoresForNewDisks(recommendation, newDiskKeys, fallback); ok {
+			return diskDatastores, SelectionMethodDRS, nil
+		}
+	}
 
-		if len(recommendation.Action) > 0 {
-			// Storage DRS typically returns one action when all disks should go
-			// to the same datastore.
-			var recommendedDatastore Datastore
+	if err != nil {
+		log.Printf("[WARN] Storage DRS failed for cluster '%s': %s. Using first-available fallback.", clusterName, err)
+	}
+	return duplicateDatastore(fallback, diskCount), SelectionMethodFallback, nil
+}
 
-			for _, action := range recommendation.Action {
-				if relocateAction, ok := action.(*types.StoragePlacementAction); ok {
-					datastoreObj := object.NewDatastore(d.Client.Client, relocateAction.Destination)
-					dsDriver := &DatastoreDriver{
-						ds:     datastoreObj,
-						driver: d,
-					}
-					info, err := dsDriver.Info("name")
-					if err != nil {
-						log.Printf("[WARN] Failed to get datastore name: %s", err)
-						continue
-					}
+func resourcePoolFromDatastores(d *VCenterDriver, datastores []Datastore) *types.ManagedObjectReference {
+	if len(datastores) == 0 {
+		return nil
+	}
 
-					ds, err := d.Finder.Datastore(d.Ctx, info.Name)
-					if err != nil {
-						log.Printf("[WARN] Failed to find datastore '%s': %s. Using direct reference.", info.Name, err)
-						recommendedDatastore = dsDriver
-					} else {
-						recommendedDatastore = &DatastoreDriver{ds: ds, driver: d}
-					}
-					break
-				}
+	dsInfo, err := datastores[0].Info("host")
+	if err != nil || len(dsInfo.Host) == 0 {
+		return nil
+	}
+
+	hostRef := dsInfo.Host[0].Key
+	host := object.NewHostSystem(d.Client.Client, hostRef)
+	hostInfo, err := host.ResourcePool(d.Ctx)
+	if err != nil {
+		return nil
+	}
+
+	ref := hostInfo.Reference()
+	return &ref
+}
+
+func (d *VCenterDriver) resolveDatastoreRef(ref types.ManagedObjectReference) (Datastore, error) {
+	datastoreObj := object.NewDatastore(d.Client.Client, ref)
+	dsDriver := &DatastoreDriver{
+		ds:     datastoreObj,
+		driver: d,
+	}
+	info, err := dsDriver.Info("name")
+	if err != nil {
+		return dsDriver, nil
+	}
+
+	ds, err := d.Finder.Datastore(d.Ctx, info.Name)
+	if err != nil {
+		log.Printf("[WARN] Failed to find datastore '%s': %s. Using direct reference.", info.Name, err)
+		return dsDriver, nil
+	}
+
+	return &DatastoreDriver{ds: ds, driver: d}, nil
+}
+
+func (d *VCenterDriver) datastoresForNewDisks(
+	recommendation types.ClusterRecommendation,
+	newDiskKeys []int32,
+	fallback Datastore,
+) ([]Datastore, bool) {
+	if len(newDiskKeys) == 0 {
+		return duplicateDatastore(fallback, 1), true
+	}
+
+	result := make([]Datastore, len(newDiskKeys))
+	resolved := make([]bool, len(newDiskKeys))
+	keyIndex := map[int32]int{}
+	for i, key := range newDiskKeys {
+		keyIndex[key] = i
+	}
+
+	for _, mapping := range diskDatastoreMappingsFromRecommendation(recommendation) {
+		idx, ok := keyIndex[mapping.diskKey]
+		if !ok {
+			continue
+		}
+		ds, err := d.resolveDatastoreRef(mapping.ref)
+		if err != nil {
+			continue
+		}
+		result[idx] = ds
+		resolved[idx] = true
+	}
+
+	unresolvedIdx := 0
+	for _, destination := range destinationOnlyActions(recommendation) {
+		ds, err := d.resolveDatastoreRef(destination)
+		if err != nil {
+			continue
+		}
+
+		if len(newDiskKeys) == 1 {
+			result[0] = ds
+			resolved[0] = true
+			break
+		}
+
+		for unresolvedIdx < len(newDiskKeys) && resolved[unresolvedIdx] {
+			unresolvedIdx++
+		}
+		if unresolvedIdx >= len(newDiskKeys) {
+			break
+		}
+		result[unresolvedIdx] = ds
+		resolved[unresolvedIdx] = true
+		unresolvedIdx++
+	}
+
+	if !allResolved(resolved) {
+		var first Datastore
+		for i, ok := range resolved {
+			if ok {
+				first = result[i]
+				break
 			}
-
-			if recommendedDatastore != nil {
-				result := make([]Datastore, len(disks))
-				for i := range len(disks) {
-					result[i] = recommendedDatastore
+		}
+		if first != nil {
+			for i := range result {
+				if !resolved[i] {
+					result[i] = first
+					resolved[i] = true
 				}
-				return result, SelectionMethodDRS, nil
 			}
 		}
 	}
 
-	// Fallback: Return first available datastore for all disks.
-	if err != nil {
-		log.Printf("[WARN] Storage DRS failed for cluster '%s': %s. Using first-available fallback.", clusterName, err)
+	if allResolved(resolved) {
+		return result, true
 	}
-	result := make([]Datastore, len(disks))
-	for i := range len(disks) {
-		result[i] = datastores[0]
+
+	return nil, false
+}
+
+func allResolved(resolved []bool) bool {
+	for _, ok := range resolved {
+		if !ok {
+			return false
+		}
 	}
-	return result, SelectionMethodFallback, nil
+	return true
+}
+
+func duplicateDatastore(datastore Datastore, count int) []Datastore {
+	result := make([]Datastore, count)
+	for i := 0; i < count; i++ {
+		result[i] = datastore
+	}
+	return result
 }
 
 // SelectDatastoreFromCluster selects a datastore from a cluster using Storage
@@ -222,9 +282,6 @@ func (d *VCenterDriver) SelectDatastoreFromCluster(
 		return nil, "", fmt.Errorf("datastore cluster '%s' contains no available datastores", clusterName)
 	}
 
-	// Create a minimal virtual machine spec for the Storage DRS placement
-	// request. Use a timestamp to make each request unique for proper Storage
-	// DRS evaluation.
 	vmSpec := types.VirtualMachineConfigSpec{
 		Name:     fmt.Sprintf("packer-placement-request-%d", time.Now().UnixNano()),
 		NumCPUs:  1,
@@ -234,21 +291,7 @@ func (d *VCenterDriver) SelectDatastoreFromCluster(
 		},
 	}
 
-	// Storage DRS requires a resource pool. Return one from the first
-	// datastore's host.
-	var resourcePoolRef *types.ManagedObjectReference
-	if len(datastores) > 0 {
-		dsInfo, err := datastores[0].Info("host")
-		if err == nil && len(dsInfo.Host) > 0 {
-			hostRef := dsInfo.Host[0].Key
-			host := object.NewHostSystem(d.Client.Client, hostRef)
-			hostInfo, err := host.ResourcePool(d.Ctx)
-			if err == nil {
-				ref := hostInfo.Reference()
-				resourcePoolRef = &ref
-			}
-		}
-	}
+	resourcePoolRef := resourcePoolFromDatastores(d, datastores)
 
 	placementResult, err := d.RequestStoragePlacement(cluster.Reference(), vmSpec, resourcePoolRef)
 	if err == nil && placementResult != nil && len(placementResult.Recommendations) > 0 {
@@ -257,29 +300,13 @@ func (d *VCenterDriver) SelectDatastoreFromCluster(
 		if len(recommendation.Action) > 0 {
 			for _, action := range recommendation.Action {
 				if relocateAction, ok := action.(*types.StoragePlacementAction); ok {
-					datastoreObj := object.NewDatastore(d.Client.Client, relocateAction.Destination)
-					dsDriver := &DatastoreDriver{
-						ds:     datastoreObj,
-						driver: d,
-					}
-					info, err := dsDriver.Info("name")
-					if err != nil {
-						log.Printf("[WARN] Failed to get datastore name: %s", err)
+					ds, err := d.resolveDatastoreRef(relocateAction.Destination)
+					if err != nil || relocateAction.Destination.Type == "" {
 						continue
 					}
 					log.Printf("[INFO] Storage DRS recommended datastore '%s' for cluster '%s'",
-						info.Name, clusterName)
-
-					ds, err := d.Finder.Datastore(d.Ctx, info.Name)
-					if err != nil {
-						log.Printf("[WARN] Failed to find datastore '%s': %s. Using direct reference.", info.Name, err)
-						return dsDriver, SelectionMethodDRS, nil
-					}
-
-					return &DatastoreDriver{
-						ds:     ds,
-						driver: d,
-					}, SelectionMethodDRS, nil
+						ds.Name(), clusterName)
+					return ds, SelectionMethodDRS, nil
 				}
 			}
 		}

--- a/builder/vsphere/driver/storage_drs_test.go
+++ b/builder/vsphere/driver/storage_drs_test.go
@@ -1,0 +1,204 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package driver
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/packer-plugin-vsphere/testing/vcsim"
+)
+
+// allSimulatorDatastores returns every Datastore in the simulator inventory,
+// sorted by reference value for deterministic ordering across test runs.
+func allSimulatorDatastores(t *testing.T, s *vcsim.Simulator) []*simulator.Datastore {
+	t.Helper()
+
+	var datastores []*simulator.Datastore
+	for _, entity := range s.Model.Map().All("Datastore") {
+		if ds, ok := entity.(*simulator.Datastore); ok {
+			datastores = append(datastores, ds)
+		}
+	}
+
+	sort.Slice(datastores, func(i, j int) bool {
+		return datastores[i].Reference().Value < datastores[j].Reference().Value
+	})
+
+	return datastores
+}
+
+func TestAllResolved(t *testing.T) {
+	testCases := []struct {
+		name     string
+		resolved []bool
+		want     bool
+	}{
+		{name: "empty slice", resolved: nil, want: true},
+		{name: "all resolved", resolved: []bool{true, true, true}, want: true},
+		{name: "one unresolved", resolved: []bool{true, false, true}, want: false},
+		{name: "none resolved", resolved: []bool{false, false}, want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := allResolved(tc.resolved); got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestDuplicateDatastore(t *testing.T) {
+	ds := &DatastoreMock{NameReturn: "ds-1"}
+
+	result := duplicateDatastore(ds, 3)
+	if len(result) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(result))
+	}
+	for i, got := range result {
+		if got != ds {
+			t.Fatalf("entry %d: expected the same datastore reference, got %#v", i, got)
+		}
+	}
+}
+
+func TestDuplicateDatastoreZeroCount(t *testing.T) {
+	result := duplicateDatastore(&DatastoreMock{}, 0)
+	if len(result) != 0 {
+		t.Fatalf("expected an empty slice, got %d entries", len(result))
+	}
+}
+
+func TestResolveDatastoreRef(t *testing.T) {
+	sim := mustVPXSimulator(t)
+	d := newSimulatorDriver(sim)
+
+	_, simDS := mustPreCreatedDatastore(t, sim)
+	ref := simDS.Reference()
+
+	resolved, err := d.resolveDatastoreRef(ref)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if resolved.Reference().Value != ref.Value {
+		t.Fatalf("expected resolved reference %q, got %q", ref.Value, resolved.Reference().Value)
+	}
+	if resolved.Name() != simDS.Name {
+		t.Fatalf("expected resolved name %q, got %q", simDS.Name, resolved.Name())
+	}
+}
+
+func TestDatastoresForNewDisks(t *testing.T) {
+	model := simulator.VPX()
+	model.Datastore = 2
+	sim := mustCustomSimulator(t, model)
+	d := newSimulatorDriver(sim)
+
+	datastores := allSimulatorDatastores(t, sim)
+	if len(datastores) < 2 {
+		t.Fatalf("expected at least 2 datastores in simulator inventory, got %d", len(datastores))
+	}
+	ds0Ref := datastores[0].Reference()
+	ds1Ref := datastores[1].Reference()
+	fallback := d.NewDatastore(&ds0Ref)
+
+	t.Run("fully resolved via per-disk locators", func(t *testing.T) {
+		recommendation := types.ClusterRecommendation{
+			Action: []types.BaseClusterAction{
+				&types.StoragePlacementAction{
+					RelocateSpec: types.VirtualMachineRelocateSpec{
+						Disk: []types.VirtualMachineRelocateSpecDiskLocator{
+							{DiskId: 2000, Datastore: ds0Ref},
+							{DiskId: 2001, Datastore: ds1Ref},
+						},
+					},
+				},
+			},
+		}
+
+		result, ok := d.datastoresForNewDisks(recommendation, []int32{2000, 2001}, fallback)
+		if !ok {
+			t.Fatal("expected all disks to resolve")
+		}
+		if len(result) != 2 {
+			t.Fatalf("expected 2 datastores, got %d", len(result))
+		}
+		if result[0].Name() != datastores[0].Name {
+			t.Fatalf("expected disk 2000 on %q, got %q", datastores[0].Name, result[0].Name())
+		}
+		if result[1].Name() != datastores[1].Name {
+			t.Fatalf("expected disk 2001 on %q, got %q", datastores[1].Name, result[1].Name())
+		}
+	})
+
+	t.Run("single destination-only action fills first gap then backfills the rest", func(t *testing.T) {
+		recommendation := types.ClusterRecommendation{
+			Action: []types.BaseClusterAction{
+				&types.StoragePlacementAction{Destination: ds1Ref},
+			},
+		}
+
+		result, ok := d.datastoresForNewDisks(recommendation, []int32{3000, 3001}, fallback)
+		if !ok {
+			t.Fatal("expected resolution to succeed via gap-filling")
+		}
+		if len(result) != 2 {
+			t.Fatalf("expected 2 datastores, got %d", len(result))
+		}
+		if result[0].Name() != datastores[1].Name {
+			t.Fatalf("expected first disk resolved from the destination-only action, got %q", result[0].Name())
+		}
+		// The second disk key has no direct recommendation, so it must be
+		// backfilled with the first resolved datastore.
+		if result[1].Name() != datastores[1].Name {
+			t.Fatalf("expected unresolved disk to be backfilled with %q, got %q", datastores[1].Name, result[1].Name())
+		}
+	})
+
+	t.Run("partially resolved disk keys fall back to the first resolved datastore", func(t *testing.T) {
+		recommendation := types.ClusterRecommendation{
+			Action: []types.BaseClusterAction{
+				&types.StoragePlacementAction{
+					RelocateSpec: types.VirtualMachineRelocateSpec{
+						Disk: []types.VirtualMachineRelocateSpecDiskLocator{
+							{DiskId: 4000, Datastore: ds1Ref},
+						},
+					},
+				},
+			},
+		}
+
+		result, ok := d.datastoresForNewDisks(recommendation, []int32{4000, 4999}, fallback)
+		if !ok {
+			t.Fatal("expected resolution to succeed via the gap-filling fallback")
+		}
+		if result[0].Name() != datastores[1].Name {
+			t.Fatalf("expected disk 4000 resolved from the recommendation, got %q", result[0].Name())
+		}
+		if result[1].Name() != datastores[1].Name {
+			t.Fatalf("expected unmatched disk key 4999 to be backfilled with %q, got %q", datastores[1].Name, result[1].Name())
+		}
+	})
+
+	t.Run("empty newDiskKeys returns a single fallback datastore", func(t *testing.T) {
+		result, ok := d.datastoresForNewDisks(types.ClusterRecommendation{}, nil, fallback)
+		if !ok {
+			t.Fatal("expected success for empty newDiskKeys")
+		}
+		if len(result) != 1 || result[0] != fallback {
+			t.Fatalf("expected a single fallback datastore, got %#v", result)
+		}
+	})
+
+	t.Run("no actions resolve anything and reports failure", func(t *testing.T) {
+		_, ok := d.datastoresForNewDisks(types.ClusterRecommendation{}, []int32{5000, 5001}, fallback)
+		if ok {
+			t.Fatal("expected resolution to fail when nothing can be resolved")
+		}
+	})
+}

--- a/builder/vsphere/driver/storage_placement.go
+++ b/builder/vsphere/driver/storage_placement.go
@@ -1,0 +1,120 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package driver
+
+import (
+	"fmt"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// StoragePlacementInput describes VM storage changes submitted to Storage DRS.
+type StoragePlacementInput struct {
+	StorageConfig   StorageConfig
+	ExistingDevices object.VirtualDeviceList
+	PrimaryDiskSize int64
+}
+
+// StorageExistingDevices returns template disks and controllers for placement.
+func StorageExistingDevices(devices object.VirtualDeviceList) object.VirtualDeviceList {
+	existing := object.VirtualDeviceList{}
+	existing = append(existing, devices.SelectByType((*types.VirtualDisk)(nil))...)
+	existing = append(existing, devices.SelectByType((*types.VirtualController)(nil))...)
+	return existing
+}
+
+// BuildStoragePlacementConfigSpec builds device changes for Storage DRS using the
+// same storage attachment logic as clone and create.
+func BuildStoragePlacementConfigSpec(input StoragePlacementInput) ([]types.BaseVirtualDeviceConfigSpec, []int32, error) {
+	var deviceChanges []types.BaseVirtualDeviceConfigSpec
+
+	if input.PrimaryDiskSize > 0 && len(input.ExistingDevices) > 0 {
+		resizeSpecs, err := buildPrimaryDiskResizeSpec(input.ExistingDevices, input.PrimaryDiskSize)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error building primary disk resize spec: %s", err)
+		}
+		deviceChanges = append(deviceChanges, resizeSpecs...)
+	}
+
+	storageSpecs, err := input.StorageConfig.AddStorageDevicesForPlacement(input.ExistingDevices)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error building storage device spec: %s", err)
+	}
+	deviceChanges = append(deviceChanges, storageSpecs...)
+
+	return deviceChanges, newVirtualDiskKeysFromConfigSpec(storageSpecs), nil
+}
+
+func buildPrimaryDiskResizeSpec(devices object.VirtualDeviceList, diskSize int64) ([]types.BaseVirtualDeviceConfigSpec, error) {
+	disk, err := findDisk(devices)
+	if err != nil {
+		return nil, err
+	}
+
+	resized := *disk
+	resized.CapacityInKB = diskSize * 1024
+	resized.CapacityInBytes = resized.CapacityInKB * 1024
+
+	return []types.BaseVirtualDeviceConfigSpec{
+		&types.VirtualDeviceConfigSpec{
+			Device:    &resized,
+			Operation: types.VirtualDeviceConfigSpecOperationEdit,
+		},
+	}, nil
+}
+
+func newVirtualDiskKeysFromConfigSpec(specs []types.BaseVirtualDeviceConfigSpec) []int32 {
+	var keys []int32
+	for _, spec := range specs {
+		configSpec := spec.GetVirtualDeviceConfigSpec()
+		if configSpec.Operation != types.VirtualDeviceConfigSpecOperationAdd {
+			continue
+		}
+		disk, ok := configSpec.Device.(*types.VirtualDisk)
+		if !ok {
+			continue
+		}
+		keys = append(keys, disk.Key)
+	}
+	return keys
+}
+
+type diskDatastoreMapping struct {
+	diskKey int32
+	ref     types.ManagedObjectReference
+}
+
+func diskDatastoreMappingsFromRecommendation(recommendation types.ClusterRecommendation) []diskDatastoreMapping {
+	var mappings []diskDatastoreMapping
+	for _, action := range recommendation.Action {
+		relocateAction, ok := action.(*types.StoragePlacementAction)
+		if !ok {
+			continue
+		}
+		for _, locator := range relocateAction.RelocateSpec.Disk {
+			mappings = append(mappings, diskDatastoreMapping{
+				diskKey: locator.DiskId,
+				ref:     locator.Datastore,
+			})
+		}
+	}
+	return mappings
+}
+
+func destinationOnlyActions(recommendation types.ClusterRecommendation) []types.ManagedObjectReference {
+	var destinations []types.ManagedObjectReference
+	for _, action := range recommendation.Action {
+		relocateAction, ok := action.(*types.StoragePlacementAction)
+		if !ok || relocateAction.Destination.Type == "" {
+			continue
+		}
+		if len(relocateAction.RelocateSpec.Disk) > 0 {
+			continue
+		}
+		destinations = append(destinations, relocateAction.Destination)
+	}
+	return destinations
+}

--- a/builder/vsphere/driver/storage_placement_test.go
+++ b/builder/vsphere/driver/storage_placement_test.go
@@ -1,0 +1,230 @@
+// © Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: MPL-2.0
+
+package driver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func TestBuildStoragePlacementConfigSpecMatchesAddStorageDevices(t *testing.T) {
+	config := StorageConfig{
+		DiskControllerType: []string{"pvscsi"},
+		Storage: []Disk{
+			{DiskSize: 4096, ControllerUnit: "scsi1:0"},
+			{DiskSize: 8192, ControllerUnit: "scsi1:1"},
+		},
+	}
+
+	existingDevices := object.VirtualDeviceList{}
+	controller, err := existingDevices.CreateSCSIController(controllerTypePVSCSI)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	existingDevices = append(existingDevices, controller)
+
+	placementSpecs, newDiskKeys, err := BuildStoragePlacementConfigSpec(StoragePlacementInput{
+		StorageConfig:   config,
+		ExistingDevices: existingDevices,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	directSpecs, err := config.AddStorageDevices(existingDevices)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if len(placementSpecs) != len(directSpecs) {
+		t.Fatalf("expected %d device specs, got %d", len(directSpecs), len(placementSpecs))
+	}
+	if len(newDiskKeys) != len(config.Storage) {
+		t.Fatalf("expected %d new disk keys, got %d", len(config.Storage), len(newDiskKeys))
+	}
+}
+
+func TestBuildStoragePlacementConfigSpecWithPrimaryResize(t *testing.T) {
+	devices := object.VirtualDeviceList{}
+	controller, err := devices.CreateSCSIController(controllerTypePVSCSI)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	devices = append(devices, controller)
+
+	disk := &types.VirtualDisk{
+		VirtualDevice: types.VirtualDevice{
+			Key: devices.NewKey(),
+		},
+		CapacityInKB: 1024,
+	}
+	controllerObj, err := devices.FindDiskController(devices.Name(controller))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	assignDiskAtUnit(devices, disk, controllerObj, 0, true)
+	devices = append(devices, disk)
+
+	specs, _, err := BuildStoragePlacementConfigSpec(StoragePlacementInput{
+		ExistingDevices: StorageExistingDevices(devices),
+		PrimaryDiskSize: 4096,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(specs) != 1 {
+		t.Fatalf("expected one resize spec, got %d", len(specs))
+	}
+
+	editSpec := specs[0].GetVirtualDeviceConfigSpec()
+	if editSpec.Operation != types.VirtualDeviceConfigSpecOperationEdit {
+		t.Fatalf("expected edit operation, got %v", editSpec.Operation)
+	}
+}
+
+func TestDiskDatastoreMappingsFromRecommendation(t *testing.T) {
+	recommendation := types.ClusterRecommendation{
+		Action: []types.BaseClusterAction{
+			&types.StoragePlacementAction{
+				RelocateSpec: types.VirtualMachineRelocateSpec{
+					Disk: []types.VirtualMachineRelocateSpecDiskLocator{
+						{DiskId: 2000, Datastore: types.ManagedObjectReference{Type: "Datastore", Value: "datastore-1"}},
+						{DiskId: 2001, Datastore: types.ManagedObjectReference{Type: "Datastore", Value: "datastore-2"}},
+					},
+				},
+			},
+		},
+	}
+
+	mappings := diskDatastoreMappingsFromRecommendation(recommendation)
+	if len(mappings) != 2 {
+		t.Fatalf("expected 2 mappings, got %d", len(mappings))
+	}
+	if mappings[0].diskKey != 2000 || mappings[1].diskKey != 2001 {
+		t.Fatalf("unexpected disk key mappings: %#v", mappings)
+	}
+}
+
+func TestDestinationOnlyActions(t *testing.T) {
+	recommendation := types.ClusterRecommendation{
+		Action: []types.BaseClusterAction{
+			&types.StoragePlacementAction{
+				Destination: types.ManagedObjectReference{Type: "Datastore", Value: "datastore-1"},
+			},
+			&types.StoragePlacementAction{
+				Destination: types.ManagedObjectReference{Type: "Datastore", Value: "datastore-2"},
+				RelocateSpec: types.VirtualMachineRelocateSpec{
+					Disk: []types.VirtualMachineRelocateSpecDiskLocator{
+						{DiskId: 1, Datastore: types.ManagedObjectReference{Type: "Datastore", Value: "ignored"}},
+					},
+				},
+			},
+		},
+	}
+
+	destinations := destinationOnlyActions(recommendation)
+	if len(destinations) != 1 {
+		t.Fatalf("expected 1 destination-only action, got %d", len(destinations))
+	}
+	if destinations[0].Value != "datastore-1" {
+		t.Fatalf("unexpected destination: %#v", destinations[0])
+	}
+}
+
+func TestAddStorageDevicesForPlacementDoesNotMutateTemplateControllers(t *testing.T) {
+	templateDevices := object.VirtualDeviceList{}
+	controller, err := templateDevices.CreateSCSIController(controllerTypePVSCSI)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	templateDevices = append(templateDevices, controller)
+
+	controllerObj, err := templateDevices.FindDiskController(templateDevices.Name(controller))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	initialDeviceCount := len(controllerObj.GetVirtualController().Device)
+
+	config := StorageConfig{
+		Storage: []Disk{{DiskSize: 4096, ControllerUnit: "scsi0:1"}},
+	}
+	_, err = config.AddStorageDevicesForPlacement(StorageExistingDevices(templateDevices))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if len(controllerObj.GetVirtualController().Device) != initialDeviceCount {
+		t.Fatal("expected template controller device list to remain unchanged during placement")
+	}
+}
+
+func TestValidateAggregateStorageCapacity(t *testing.T) {
+	devices := object.VirtualDeviceList{}
+	controller, err := devices.CreateSCSIController(controllerTypeLSILogic)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	devices = append(devices, controller)
+
+	controllerObj, err := devices.FindDiskController(devices.Name(controller))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	for i := 0; i < maxLSISCSIDisksPerVM; i++ {
+		disk := &types.VirtualDisk{
+			VirtualDevice: types.VirtualDevice{
+				Key:           devices.NewKey(),
+				ControllerKey: controllerObj.GetVirtualController().Key,
+			},
+			CapacityInKB: 1024,
+		}
+		devices = append(devices, disk)
+	}
+
+	counts := countVirtualDisksByKind(devices)
+	if counts[ControllerKindSCSI] != maxLSISCSIDisksPerVM {
+		t.Fatalf("expected %d SCSI disks in fixture, got %d", maxLSISCSIDisksPerVM, counts[ControllerKindSCSI])
+	}
+
+	err = validateAggregateStorageCapacity(devices)
+	if err != nil {
+		t.Fatalf("expected 60 SCSI disks to be valid, got %v", err)
+	}
+
+	extra := &types.VirtualDisk{
+		VirtualDevice: types.VirtualDevice{
+			Key:           devices.NewKey(),
+			ControllerKey: controllerObj.GetVirtualController().Key,
+		},
+		CapacityInKB: 1024,
+	}
+	devices = append(devices, extra)
+	err = validateAggregateStorageCapacity(devices)
+	if err == nil || !strings.Contains(err.Error(), "supports maximum 60 SCSI disks") {
+		t.Fatalf("expected aggregate SCSI capacity error after extra disk, got %v", err)
+	}
+}
+
+func TestNewVirtualDiskKeysFromConfigSpec(t *testing.T) {
+	specs := []types.BaseVirtualDeviceConfigSpec{
+		&types.VirtualDeviceConfigSpec{
+			Operation: types.VirtualDeviceConfigSpecOperationAdd,
+			Device:    &types.VirtualDisk{VirtualDevice: types.VirtualDevice{Key: 2000}},
+		},
+		&types.VirtualDeviceConfigSpec{
+			Operation: types.VirtualDeviceConfigSpecOperationAdd,
+			Device:    &types.VirtualDisk{VirtualDevice: types.VirtualDevice{Key: 2001}},
+		},
+	}
+
+	keys := newVirtualDiskKeysFromConfigSpec(specs)
+	if len(keys) != 2 || keys[0] != 2000 || keys[1] != 2001 {
+		t.Fatalf("unexpected disk keys: %#v", keys)
+	}
+}

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -441,13 +441,7 @@ func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) 
 		configSpec.DeviceChange = append(configSpec.DeviceChange, deviceResizeSpec...)
 	}
 
-	virtualDisks := devices.SelectByType((*types.VirtualDisk)(nil))
-	virtualControllers := devices.SelectByType((*types.VirtualController)(nil))
-
-	// Use existing devices to avoid overlapping configuration.
-	existingDevices := object.VirtualDeviceList{}
-	existingDevices = append(existingDevices, virtualDisks...)
-	existingDevices = append(existingDevices, virtualControllers...)
+	existingDevices := StorageExistingDevices(devices)
 
 	storageConfigSpec, err := config.StorageConfig.AddStorageDevices(existingDevices)
 	if err != nil {

--- a/builder/vsphere/driver/vm_mock.go
+++ b/builder/vsphere/driver/vm_mock.go
@@ -89,6 +89,9 @@ type VirtualMachineMock struct {
 	CloneConfig    *CloneConfig
 	CloneError     error
 	CloneReturnNil bool
+
+	DevicesReturn object.VirtualDeviceList
+	DevicesErr    error
 }
 
 func (vm *VirtualMachineMock) Info(params ...string) (*mo.VirtualMachine, error) {
@@ -96,7 +99,10 @@ func (vm *VirtualMachineMock) Info(params ...string) (*mo.VirtualMachine, error)
 }
 
 func (vm *VirtualMachineMock) Devices() (object.VirtualDeviceList, error) {
-	return object.VirtualDeviceList{}, nil
+	if vm.DevicesReturn != nil {
+		return vm.DevicesReturn, vm.DevicesErr
+	}
+	return object.VirtualDeviceList{}, vm.DevicesErr
 }
 
 func (vm *VirtualMachineMock) FloppyDevices() (object.VirtualDeviceList, error) {

--- a/builder/vsphere/driver/vm_test.go
+++ b/builder/vsphere/driver/vm_test.go
@@ -212,6 +212,180 @@ func TestVirtualMachineDriver_CloneWithPrimaryDiskResize(t *testing.T) {
 	}
 }
 
+func TestVirtualMachineDriver_CloneWithExplicitControllerUnit(t *testing.T) {
+	sim := mustVPXSimulator(t)
+
+	_, datastore := mustPreCreatedDatastore(t, sim)
+	vm, _ := mustPreCreatedVM(t, sim)
+
+	config := &CloneConfig{
+		Name:      "mock name",
+		Host:      "DC0_H0",
+		Datastore: datastore.Name,
+		StorageConfig: StorageConfig{
+			Storage: []Disk{
+				{
+					DiskSize:       4096,
+					ControllerUnit: "scsi0:1",
+				},
+			},
+		},
+	}
+
+	clonedVM, err := vm.Clone(context.TODO(), config)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	devices, err := clonedVM.Devices()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	var disks []*types.VirtualDisk
+	for _, device := range devices {
+		if disk, ok := device.(*types.VirtualDisk); ok {
+			disks = append(disks, disk)
+		}
+	}
+
+	if len(disks) != 2 {
+		t.Fatalf("unexpected result: expected '2', but returned '%d'", len(disks))
+	}
+
+	var added *types.VirtualDisk
+	for _, disk := range disks {
+		if disk.UnitNumber != nil && *disk.UnitNumber == 1 {
+			added = disk
+			break
+		}
+	}
+	if added == nil {
+		t.Fatal("expected to find disk attached at scsi0:1")
+	}
+	if added.CapacityInKB != 4096*1024 {
+		t.Fatalf("unexpected result: expected '%d', but returned '%d'", 4096*1024, added.CapacityInKB)
+	}
+
+	controllers := devices.SelectByType((*types.VirtualSCSIController)(nil))
+	if len(controllers) != 1 {
+		t.Fatalf("unexpected result: expected '1' SCSI controller, but returned '%d'", len(controllers))
+	}
+}
+
+func TestVirtualMachineDriver_CloneWithExplicitUnitNewController(t *testing.T) {
+	sim := mustVPXSimulator(t)
+
+	_, datastore := mustPreCreatedDatastore(t, sim)
+	vm, _ := mustPreCreatedVM(t, sim)
+
+	config := &CloneConfig{
+		Name:      "mock name",
+		Host:      "DC0_H0",
+		Datastore: datastore.Name,
+		StorageConfig: StorageConfig{
+			DiskControllerType: []string{"pvscsi"},
+			Storage: []Disk{
+				{
+					DiskSize:       4096,
+					ControllerUnit: "scsi1:0",
+				},
+			},
+		},
+	}
+
+	clonedVM, err := vm.Clone(context.TODO(), config)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	devices, err := clonedVM.Devices()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	controllers := devices.SelectByType((*types.VirtualSCSIController)(nil))
+	if len(controllers) != 2 {
+		t.Fatalf("unexpected result: expected '2' SCSI controllers, but returned '%d'", len(controllers))
+	}
+
+	var added *types.VirtualDisk
+	for _, device := range devices {
+		disk, ok := device.(*types.VirtualDisk)
+		if !ok {
+			continue
+		}
+		if disk.UnitNumber != nil && *disk.UnitNumber == 0 {
+			controllerKey := disk.GetVirtualDevice().ControllerKey
+			for _, controllerDevice := range devices {
+				controller, ok := controllerDevice.(types.BaseVirtualSCSIController)
+				if !ok {
+					continue
+				}
+				if controller.GetVirtualSCSIController().Key == controllerKey &&
+					controller.GetVirtualSCSIController().BusNumber == 1 {
+					added = disk
+					break
+				}
+			}
+		}
+	}
+	if added == nil {
+		t.Fatal("expected to find disk attached at scsi1:0")
+	}
+}
+
+func TestVirtualMachineDriver_CloneWithMixedLegacyAndExplicit(t *testing.T) {
+	sim := mustVPXSimulator(t)
+
+	_, datastore := mustPreCreatedDatastore(t, sim)
+	vm, _ := mustPreCreatedVM(t, sim)
+
+	config := &CloneConfig{
+		Name:      "mock name",
+		Host:      "DC0_H0",
+		Datastore: datastore.Name,
+		StorageConfig: StorageConfig{
+			DiskControllerType: []string{"pvscsi", "pvscsi"},
+			Storage: []Disk{
+				{
+					DiskSize:        2048,
+					ControllerIndex: 0,
+				},
+				{
+					DiskSize:       4096,
+					ControllerUnit: "scsi0:1",
+				},
+			},
+		},
+	}
+
+	clonedVM, err := vm.Clone(context.TODO(), config)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	devices, err := clonedVM.Devices()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	var explicitDisk *types.VirtualDisk
+	for _, device := range devices {
+		disk, ok := device.(*types.VirtualDisk)
+		if !ok {
+			continue
+		}
+		if disk.UnitNumber != nil && *disk.UnitNumber == 1 {
+			explicitDisk = disk
+			break
+		}
+	}
+	if explicitDisk == nil {
+		t.Fatal("expected explicit disk at scsi0:1")
+	}
+}
+
 func TestVirtualMachineDriver_CloneWithMacAddress(t *testing.T) {
 	sim := mustVPXSimulator(t)
 

--- a/builder/vsphere/iso/step_create.go
+++ b/builder/vsphere/iso/step_create.go
@@ -139,6 +139,12 @@ func (c *CreateConfig) Prepare() []error {
 	}
 	errs = append(errs, c.StorageConfig.Prepare()...)
 
+	for i, storage := range c.StorageConfig.Storage {
+		if storage.DiskControllerUnit != "" {
+			errs = append(errs, fmt.Errorf("storage[%d]: 'disk_controller_unit' is only supported by the vsphere-clone builder", i))
+		}
+	}
+
 	if c.GuestOSType == "" {
 		c.GuestOSType = "otherGuest"
 	}
@@ -224,8 +230,14 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 	}
 
 	// Handle multi-disk placement when using a datastore cluster.
+	placementInput := driver.StoragePlacementInput{
+		StorageConfig: driver.StorageConfig{
+			DiskControllerType: s.Config.StorageConfig.DiskControllerType,
+			Storage:            disks,
+		},
+	}
 	datastoreName, datastoreRefs := common.ResolveMultiDiskDatastoreRefs(
-		ui, d, s.Location.DatastoreCluster, disks, primaryDatastore, datastoreName,
+		ui, d, s.Location.DatastoreCluster, placementInput, primaryDatastore, datastoreName,
 	)
 
 	vm, err := d.CreateVM(&driver.CreateConfig{

--- a/builder/vsphere/iso/step_create_test.go
+++ b/builder/vsphere/iso/step_create_test.go
@@ -80,6 +80,21 @@ func TestCreateConfig_Prepare(t *testing.T) {
 			expectedErrMsg: "storage[0].'disk_controller_index' references an unknown disk controller",
 		},
 		{
+			name: "Storage rejects disk_controller_unit",
+			config: &CreateConfig{
+				StorageConfig: common.StorageConfig{
+					Storage: []common.DiskConfig{
+						{
+							DiskSize:           32768,
+							DiskControllerUnit: "scsi0:1",
+						},
+					},
+				},
+			},
+			fail:           true,
+			expectedErrMsg: "storage[0]: 'disk_controller_unit' is only supported by the vsphere-clone builder",
+		},
+		{
 			name: "USBController validate 'usb' and 'xhci' can be set together",
 			config: &CreateConfig{
 				USBController: []string{"usb", "xhci"},

--- a/docs-partials/builder/vsphere/common/DiskConfig-not-required.mdx
+++ b/docs-partials/builder/vsphere/common/DiskConfig-not-required.mdx
@@ -8,5 +8,12 @@
 
 - `disk_controller_index` (int) - The assigned disk controller for the disk.
   Defaults to the first controller, `(0)`.
+  Mutually exclusive with `disk_controller_unit`.
+
+- `disk_controller_unit` (string) - Explicit controller address for the disk when cloning from a `template`
+  or deploying a VM template `content_library_source`.
+  Format: `{type}{bus}:{unit}` such as `scsi0:1`, `nvme0:0`, or `sata0:2`.
+  Only supported by the `vsphere-clone` builder. Mutually exclusive with
+  `disk_controller_index`.
 
 <!-- End of code generated from the comments of the DiskConfig struct in builder/vsphere/common/storage_config.go; -->

--- a/docs/builders/vsphere-clone.mdx
+++ b/docs/builders/vsphere-clone.mdx
@@ -119,17 +119,18 @@ clone options apply when deploying from a `content_library_source`.
 
 @include 'builder/vsphere/common/DiskConfig-not-required.mdx'
 
-The following example creates a 15GB and a 20GB disk on the virtual machine.
-The second disk is thin provisioned:
+The following example creates a 10 GiB (15360 MiB) disk and a 20 GiB
+(20480 MiB) disk on the virtual machine. The second disk is thin
+provisioned:
 
 HCL Example:
 
 ```hcl
 storage {
-  disk_size = 15000
+  disk_size = 10240
 }
 storage {
-  disk_size             = 20000
+  disk_size             = 20480
   disk_thin_provisioned = true
 }
 ```
@@ -139,14 +140,262 @@ JSON Example:
 ```json
 "storage": [
   {
-    "disk_size": 15000
+    "disk_size": 10240
   },
   {
-    "disk_size": 20000,
+    "disk_size": 20480,
     "disk_thin_provisioned": true
   }
 ]
 ```
+
+The following example adds disks to an existing template controller at explicit
+units without creating a new controller. `disk_controller_type` only matters
+when a new controller must be created, so it is not required here, since
+every address (`scsi0:1`, `scsi0:2`) targets a bus that already exists on the
+template:
+
+HCL Example:
+
+```hcl
+storage {
+  disk_size            = 10240
+  disk_controller_unit = "scsi0:1"
+}
+storage {
+  disk_size            = 20480
+  disk_controller_unit = "scsi0:2"
+}
+```
+
+JSON Example:
+
+```json
+"storage": [
+  {
+    "disk_size": 10240,
+    "disk_controller_unit": "scsi0:1"
+  },
+  {
+    "disk_size": 20480,
+    "disk_controller_unit": "scsi0:2"
+  }
+]
+```
+
+~> **Note:** `disk_controller_unit` is only supported by the `vsphere-clone`
+builder when cloning from a `template` or deploying a VM template
+`content_library_source` (the "Template-backed" group in
+[Source Compatibility](#source-compatibility)). It is mutually exclusive with
+`disk_controller_index` on the same `storage` block.
+
+When every `storage` block uses `disk_controller_unit` and some addresses
+reference controllers that do not exist on the template, add matching entries
+to `disk_controller_type` for on-demand controller creation. The first entry
+creates the controller for the first missing bus, and so on.
+
+HCL Example:
+
+```hcl
+disk_controller_type = ["pvscsi"]
+storage {
+  disk_size            = 10240
+  disk_controller_unit = "scsi1:0"
+}
+```
+
+JSON Example:
+
+```json
+"disk_controller_type": ["pvscsi"],
+"storage": [
+  {
+    "disk_size": 10240,
+    "disk_controller_unit": "scsi1:0"
+  }
+]
+```
+
+The following example combines legacy `disk_controller_index` placement with
+explicit `disk_controller_unit` addresses in one clone. When any storage block
+uses `disk_controller_index`, every entry in `disk_controller_type` is created
+as a new controller before explicit disks are attached. On-demand controller
+creation for explicit units then uses any additional `disk_controller_type`
+entries beyond that initial list.
+
+HCL Example:
+
+```hcl
+disk_controller_type = ["pvscsi", "pvscsi"]
+storage {
+  disk_size             = 10240
+  disk_controller_index = 0
+}
+storage {
+  disk_size            = 20480
+  disk_controller_unit = "scsi0:1"
+}
+```
+
+JSON Example:
+
+```json
+"disk_controller_type": ["pvscsi", "pvscsi"],
+"storage": [
+  {
+    "disk_size": 10240,
+    "disk_controller_index": 0
+  },
+  {
+    "disk_size": 20480,
+    "disk_controller_unit": "scsi0:1"
+  }
+]
+```
+
+The following example extends a template that already has `scsi0` and `scsi1`,
+attaches disks to existing controllers at explicit units, and creates a new
+`scsi2` controller for an additional disk:
+
+HCL Example:
+
+```hcl
+disk_controller_type = ["pvscsi"]
+storage {
+  disk_size            = 10240
+  disk_controller_unit = "scsi0:1"
+}
+storage {
+  disk_size            = 20480
+  disk_controller_unit = "scsi1:0"
+}
+storage {
+  disk_size            = 40960
+  disk_controller_unit = "scsi2:0"
+}
+```
+
+JSON Example:
+
+```json
+"disk_controller_type": ["pvscsi"],
+"storage": [
+  {
+    "disk_size": 10240,
+    "disk_controller_unit": "scsi0:1"
+  },
+  {
+    "disk_size": 20480,
+    "disk_controller_unit": "scsi1:0"
+  },
+  {
+    "disk_size": 40960,
+    "disk_controller_unit": "scsi2:0"
+  }
+]
+```
+
+~> **Note:** PVSCSI controllers support units 0-6 and 8-64. Unit 7 is
+reserved for the controller device. LSI Logic, LSI Logic SAS, and BusLogic
+controllers support units 0-6 and 8-15.
+
+The following example creates two new controllers of *different* types.
+`disk_controller_type` entries are consumed in the order distinct new buses
+are first referenced by a `storage` block: `scsi1` is created first, so it
+uses `disk_controller_type[0]` (LSI Logic, unit range 0-6 and 8-15), and
+`scsi2` is created next, so it uses `disk_controller_type[1]` (PVSCSI, unit
+range 0-6 and 8-64). Multiple `storage` blocks that reference the same bus
+share its type without consuming an additional `disk_controller_type` entry:
+
+HCL Example:
+
+```hcl
+disk_controller_type = ["lsilogic", "pvscsi"]
+storage {
+  disk_size            = 10240
+  disk_controller_unit = "scsi1:0"
+}
+storage {
+  disk_size            = 20480
+  disk_controller_unit = "scsi2:0"
+}
+storage {
+  disk_size            = 40960
+  disk_controller_unit = "scsi2:50"
+}
+```
+
+JSON Example:
+
+```json
+"disk_controller_type": ["lsilogic", "pvscsi"],
+"storage": [
+  {
+    "disk_size": 10240,
+    "disk_controller_unit": "scsi1:0"
+  },
+  {
+    "disk_size": 20480,
+    "disk_controller_unit": "scsi2:0"
+  },
+  {
+    "disk_size": 40960,
+    "disk_controller_unit": "scsi2:50"
+  }
+]
+```
+
+`disk_controller_type` entries are consumed in bus-reference order across
+*all* controller kinds combined, not per-kind. The following example creates
+a new SCSI, SATA, and NVMe controller in the same clone: `scsi1` is
+referenced first, so it uses `disk_controller_type[0]` (PVSCSI); `sata0` is
+referenced next, so it uses `disk_controller_type[1]` (SATA); and `nvme0` is
+referenced last, so it uses `disk_controller_type[2]` (NVMe):
+
+HCL Example:
+
+```hcl
+disk_controller_type = ["pvscsi", "sata", "nvme"]
+storage {
+  disk_size            = 10240
+  disk_controller_unit = "scsi1:0"
+}
+storage {
+  disk_size            = 20480
+  disk_controller_unit = "sata0:0"
+}
+storage {
+  disk_size            = 40960
+  disk_controller_unit = "nvme0:0"
+}
+```
+
+JSON Example:
+
+```json
+"disk_controller_type": ["pvscsi", "sata", "nvme"],
+"storage": [
+  {
+    "disk_size": 10240,
+    "disk_controller_unit": "scsi1:0"
+  },
+  {
+    "disk_size": 20480,
+    "disk_controller_unit": "sata0:0"
+  },
+  {
+    "disk_size": 40960,
+    "disk_controller_unit": "nvme0:0"
+  }
+]
+```
+
+~> **Note:** Because the `disk_controller_type` index is assigned by
+reference order rather than by kind, the entry at that index must match the
+kind of the bus being created (SCSI, SATA, or NVMe). For example, referencing
+`nvme0` before `scsi1` while `disk_controller_type` is
+`["lsilogic", "nvme"]` would place `nvme0` at index `0` (`lsilogic`), a
+SCSI-family type. This mismatch is rejected at `packer validate` time.
 
 The following example uses two PVSCSI controllers and two disks on each
 controller:
@@ -156,19 +405,19 @@ HCL Example:
 ```hcl
 disk_controller_type = ["pvscsi", "pvscsi"]
 storage {
-  disk_size             = 15000
+  disk_size             = 10240
   disk_controller_index = 0
 }
 storage {
-  disk_size             = 15000
+  disk_size             = 20480
   disk_controller_index = 0
 }
 storage {
-  disk_size             = 15000
+  disk_size             = 40960
   disk_controller_index = 1
 }
 storage {
-  disk_size             = 15000
+  disk_size             = 81920
   disk_controller_index = 1
 }
 ```
@@ -179,19 +428,19 @@ JSON Example:
 "disk_controller_type": ["pvscsi", "pvscsi"],
 "storage": [
   {
-    "disk_size": 15000,
+    "disk_size": 10240,
     "disk_controller_index": 0
   },
   {
-    "disk_size": 15000,
+    "disk_size": 20480,
     "disk_controller_index": 0
   },
   {
-    "disk_size": 15000,
+    "disk_size": 40960,
     "disk_controller_index": 1
   },
   {
-    "disk_size": 15000,
+    "disk_size": 81920,
     "disk_controller_index": 1
   }
 ]


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

Added `disk_controller_unit` to `storage` blocks so `vsphere-clone` can attach a disk to an explicit controller and unit (e.g. `scsi0:1`, `nvme0:0`, `sata0:2`) instead of only the legacy index-based `disk_controller_index`. 

Explicit units can target a controller that already exists on the template, or create a new one on demand from `disk_controller_type`, and can be mixed with legacy index-based `storage` blocks in the same clone.

The following example adds disks to an existing template controller at explicit units without creating a new controller. When every `storage` block uses `disk_controller_unit`, `disk_controller_type` is not required:

HCL Example:

```hcl
storage {
  disk_size            = 10248
  disk_controller_unit = "scsi0:1"
}
storage {
  disk_size            = 20480
  disk_controller_unit = "scsi0:2"
}
```

**Note:** `disk_controller_unit` is only supported by the `vsphere-clone` builder when cloning from a `template`. It is mutually exclusive with `disk_controller_index` on the same `storage` block.

When every `storage` block uses `disk_controller_unit` and some addressed reference controllers that do not exist on the template, add matching entries to `disk_controller_type` for on-demand controller creation. The first entry creates the controller for the first missing bus, and so on.

HCL Example:

```hcl
disk_controller_type = ["pvscsi"]
storage {
  disk_size            = 10240
  disk_controller_unit = "scsi1:0"
}
```

The following example combines legacy `disk_controller_index` placement with explicit `disk_controller_unit` addresses in one clone. When any storage block uses `disk_controller_index`, every entry in `disk_controller_type` is created as a new controller before explicit disks are attached. On-demand controller creation for explicit units then uses any additional `disk_controller_type` entries beyond that initial list.

HCL Example:

```hcl
disk_controller_type = ["pvscsi", "pvscsi"]
storage {
  disk_size             = 10240
  disk_controller_index = 0
}
storage {
  disk_size            = 20480
  disk_controller_unit = "scsi0:1"
}
```

The following example extends a template that already has `scsi0` and `scsi1`, attaches disks to existing controllers at explicit units, and creates a new `scsi2` controller for an additional disk:

HCL Example:

```hcl
disk_controller_type = ["pvscsi"]
storage {
  disk_size            = 10240
  disk_controller_unit = "scsi0:1"
}
storage {
  disk_size            = 20480
  disk_controller_unit = "scsi1:0"
}
storage {
  disk_size            = 40960
  disk_controller_unit = "scsi2:0"
}
```

**Note:** PVSCSI controllers support units 0-6 and 8-64. Unit 7 is reserved for the controller device. LSI Logic, LSI Logic SAS, and BusLogic controllers support units 0-6 and 8-15.

The following example creates two new controllers of *different* types. `disk_controller_type` entries are consumed in the order distinct new buses are first referenced by a `storage` block: `scsi1` is created first, so it uses `disk_controller_type[0]` (LSI Logic, unit range 0-6 and 8-15), and `scsi2` is created next, so it uses `disk_controller_type[1]` (PVSCSI, unit range 0-6 and 8-64). Multiple `storage` blocks that reference the same bus share its type without consuming an additional `disk_controller_type` entry:

HCL Examples:


```icl
  disk_controller_type = ["nvme", "sata"]

  storage {
    disk_size            = 10240
    disk_controller_unit = "nvme0:0"
  }
  storage {
    disk_size            = 20480
    disk_controller_unit = "sata0:0"
  }
```

```hcl
disk_controller_type = ["lsilogic", "pvscsi"]
storage {
  disk_size            = 10240
  disk_controller_unit = "scsi1:0"
}
storage {
  disk_size            = 20480
  disk_controller_unit = "scsi2:0"
}
storage {
  disk_size            = 40960
  disk_controller_unit = "scsi2:50"
}
```

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [x] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [ ] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been added or updated.
- [x] Tests have been completed.

Output:

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [x] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

Closes #84 

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->