### PR TITLE
refactor: use errors.Is for sentinel error checks

### DIFF
--- a/builder/vsphere/clone/step_customize_test.go
+++ b/builder/vsphere/clone/step_customize_test.go
@@ -5,6 +5,7 @@
 package clone
 
 import (
+	"errors"
 	"slices"
 	"testing"
 
@@ -25,17 +26,17 @@ func TestSysprepFieldsMutuallyExclusive(t *testing.T) {
 
 	// Expected error message
 	expectedError := errCustomizeOptionMutualExclusive
-	_, errors := config.Prepare()
+	_, errs := config.Prepare()
 
 	// Make sure we only received on error
 	expectedErrorLength := 1
-	if len(errors) != expectedErrorLength {
-		t.Fatalf("unexpected result: expected '%d', but returned: '%d'", expectedErrorLength, len(errors))
+	if len(errs) != expectedErrorLength {
+		t.Fatalf("unexpected result: expected '%d', but returned: '%d'", expectedErrorLength, len(errs))
 	}
 
 	// Validate the error messages are what we expect.
-	if errors[0] != expectedError {
-		t.Fatalf("unexpected error: expected '%s', but returned: '%s'", expectedError, errors[0])
+	if !errors.Is(errs[0], expectedError) {
+		t.Fatalf("unexpected error: expected '%s', but returned: '%s'", expectedError, errs[0])
 	}
 }
 

--- a/builder/vsphere/common/step_reattach_cdrom.go
+++ b/builder/vsphere/common/step_reattach_cdrom.go
@@ -9,6 +9,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 
@@ -85,7 +86,7 @@ func (s *StepReattachCDRom) Run(_ context.Context, state multistep.StateBag) mul
 	if nAttachableCdroms > 0 {
 		// If the CD-ROM device type is SATA, make sure SATA controller is present.
 		if s.CDRomConfig.CdromType == "sata" {
-			if _, err := vm.FindSATAController(); err == driver.ErrNoSataController {
+			if _, err := vm.FindSATAController(); errors.Is(err, driver.ErrNoSataController) {
 				ui.Say("Adding SATA controller...")
 				if err := vm.AddSATAController(); err != nil {
 					state.Put("error", fmt.Errorf("error adding sata controller: %v", err))

--- a/builder/vsphere/driver/vm.go
+++ b/builder/vsphere/driver/vm.go
@@ -510,7 +510,7 @@ func (vm *VirtualMachineDriver) Clone(ctx context.Context, config *CloneConfig) 
 
 	info, err := task.WaitForResult(ctx, nil)
 	if err != nil {
-		if ctx.Err() == context.Canceled {
+		if errors.Is(ctx.Err(), context.Canceled) {
 			err = task.Cancel(context.TODO())
 			return nil, err
 		}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 no-inline-html -->

<!--
    NOTE: Do NOT enter content between the comment markers <!- and ->.

    In order to have the best experience with our community, we recommend that you read the code of
    conduct and contributing guidelines before submitting a pull request.

    By submitting this pull request, you confirm that you have read, understood, and agreed to the
    project's code of conduct and contributing guidelines.

    Please use conventional commits to format the title of the pull request and the commit messages.

    For more information, please refer to https://www.conventionalcommits.org and the contributing
    guidelines for this project.
-->

### Summary

Replaced direct error equality checks with `errors.Is`.

Since Go 1.13, errors can be wrapped using the fmt.Errorf function with the %w verb. Therefore, direct comparison of errors using the equality check fails on wrapped errors. The preferred way of checking for a specific error is to use the errors.Is function from the standard library as this function traverses the chain of the wrapped errors while checking for a specific error.

### Type

<!--
    Please check the one(s) that applies to this pull request using "x".
-->

- [ ] `fix`: Bug Fix
- [ ] `feat`: Feature or Enhancement
- [ ] `docs`: Documentation
- [x] `refactor`: Refactoring
- [ ] `chore`: Build, Dependencies, Workflows, etc.
- [ ] `other`: Other (Please describe.)

### Breaking Changes?

<!--
    Please check the one that applies to this pull request using "x".
    If this pull request contains a breaking change, please describe the impact and mitigation path.
-->

- [ ] Yes, there are breaking changes.
- [x] No, there are no breaking changes.

### Tests

<!--
    Please check the one(s) that applies to this pull request using "x".
    For bug fixes and enhancements/features, please ensure that tests and documentation have been completed and provide details.
-->

- [x] Tests have been added or updated.
- [x] Tests have been completed.

Output:

<!--
    Please provide the output of the acceptance tests as applicable.
-->

### Documentation

<!--
    Please check the one(s) that applies to this pull request using "x".
    For enhancements/features, please ensure that documentation has been updated.
-->

- [ ] Documentation has been added or updated.

### Issue References

<!--
    Is this related to any GitHub issue(s)? If so, please provide the issue number(s) that are closed or resolved by this pull request.

    For bug fixes and enhancements/features, please ensure that a GitHub issue has been created and provide the issue number(s) here.

    Please use the 'Closes', 'Resolves', or 'Fixes' keywords followed by a hash and issue number.
    This will link the pull request to the issue(s) and automatically close them when the pull request is merged.

    Example:

    Closes #000
    Resolves #001
    Fixes #002
-->

### Release Note

<!--
    Please provide context for the release notes.

    For example:

    ```
    - Added support for foo. (#xxx)
    ```
-->

### Additional Information

<!--
    Please provide any additional information that may be helpful.
-->